### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -1,0 +1,110 @@
+name: Release Assets And Homebrew
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  # 默认发布到维护者预期的 Homebrew tap。
+  # 如需迁移到别的 tap，可在仓库变量 HOMEBREW_TAP_REPO 中覆盖。
+  HOMEBREW_TAP_REPO: ${{ vars.HOMEBREW_TAP_REPO || 'thedavidweng/homebrew-tap' }}
+
+jobs:
+  release:
+    runs-on: macos-15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Prepare bundled tag resource
+        run: |
+          python3 -m pip install --upgrade pip python-dotenv
+          mkdir -p Resources
+          python3 export_tags.py || test -f ../Resources/tags.json
+        working-directory: pixiv-tags
+
+      - name: Verify bundled tag resource
+        run: test -f Resources/tags.json
+
+      - name: Build release artifacts
+        run: scripts/build.sh --clean
+
+      - name: Collect release metadata
+        id: release_meta
+        run: |
+          export VERSION="${GITHUB_REF_NAME#v}"
+          export GITHUB_OUTPUT
+          python3 - <<'PY'
+          import hashlib
+          import os
+          from pathlib import Path
+
+          files = {
+              "arm64_sha": Path("build/Pixiv-SwiftUI-arm64.dmg"),
+              "intel_sha": Path("build/Pixiv-SwiftUI-x86_64.dmg"),
+          }
+
+          output_path = Path(os.environ["GITHUB_OUTPUT"])
+          with output_path.open("a", encoding="utf-8") as fh:
+              fh.write(f"version={os.environ['VERSION']}\n")
+              for key, path in files.items():
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  fh.write(f"{key}={digest}\n")
+          PY
+
+      - name: Create or update GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            build/Pixiv-SwiftUI.ipa
+            build/Pixiv-SwiftUI-arm64.dmg
+            build/Pixiv-SwiftUI-x86_64.dmg
+          generate_release_notes: true
+
+      - name: Check out Homebrew tap
+        # 只有配置了 tap 推送凭据时才执行；未配置不会影响 GitHub Release 构建与发布。
+        if: ${{ env.HOMEBREW_TAP_REPO != '' && secrets.HOMEBREW_TAP_TOKEN != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.HOMEBREW_TAP_REPO }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Verify Homebrew tap configuration
+        # 上游维护者接手时，通常只需要在仓库 Secrets 中添加 HOMEBREW_TAP_TOKEN。
+        if: ${{ env.HOMEBREW_TAP_REPO == '' || secrets.HOMEBREW_TAP_TOKEN == '' }}
+        run: |
+          echo "Homebrew tap publish is skipped."
+          echo "Set repository variable HOMEBREW_TAP_REPO and secret HOMEBREW_TAP_TOKEN to enable it."
+
+      - name: Update Homebrew cask
+        if: ${{ env.HOMEBREW_TAP_REPO != '' && secrets.HOMEBREW_TAP_TOKEN != '' }}
+        run: |
+          bash scripts/update_homebrew_cask.sh \
+            --tap-path homebrew-tap \
+            --version "${{ steps.release_meta.outputs.version }}" \
+            --arm64-sha "${{ steps.release_meta.outputs.arm64_sha }}" \
+            --intel-sha "${{ steps.release_meta.outputs.intel_sha }}"
+
+      - name: Commit and push Homebrew tap update
+        if: ${{ env.HOMEBREW_TAP_REPO != '' && secrets.HOMEBREW_TAP_TOKEN != '' }}
+        run: |
+          git -C homebrew-tap config user.name "github-actions[bot]"
+          git -C homebrew-tap config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C homebrew-tap add Casks/pixiv-swiftui.rb
+          if git -C homebrew-tap diff --cached --quiet; then
+            echo "No tap changes to commit"
+            exit 0
+          fi
+          git -C homebrew-tap commit -m "chore: update pixiv-swiftui to v${{ steps.release_meta.outputs.version }}"
+          git -C homebrew-tap push

--- a/scripts/update_homebrew_cask.sh
+++ b/scripts/update_homebrew_cask.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: update_homebrew_cask.sh --tap-path PATH --version VERSION --arm64-sha SHA --intel-sha SHA
+
+Updates Casks/pixiv-swiftui.rb in a local homebrew-tap checkout.
+
+Required arguments:
+  --tap-path     Path to the homebrew-tap repository
+  --version      Version without leading v
+  --arm64-sha    SHA256 for Pixiv-SwiftUI-arm64.dmg
+  --intel-sha    SHA256 for Pixiv-SwiftUI-x86_64.dmg
+EOF
+}
+
+TAP_PATH=""
+VERSION=""
+ARM64_SHA=""
+INTEL_SHA=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tap-path)
+      TAP_PATH="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --arm64-sha)
+      ARM64_SHA="$2"
+      shift 2
+      ;;
+    --intel-sha)
+      INTEL_SHA="$2"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      show_help >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TAP_PATH" || -z "$VERSION" || -z "$ARM64_SHA" || -z "$INTEL_SHA" ]]; then
+  show_help >&2
+  exit 1
+fi
+
+CASK_PATH="$TAP_PATH/Casks/pixiv-swiftui.rb"
+
+if [[ ! -f "$CASK_PATH" ]]; then
+  echo "Cask file not found: $CASK_PATH" >&2
+  exit 1
+fi
+
+export CASK_PATH VERSION ARM64_SHA INTEL_SHA
+
+python3 - <<'PY'
+import os
+import re
+from pathlib import Path
+
+cask_path = Path(os.environ["CASK_PATH"])
+content = cask_path.read_text(encoding="utf-8")
+
+content = re.sub(r'version "[^"]+"', f'version "{os.environ["VERSION"]}"', content, count=1)
+content = re.sub(
+    r'sha256 arm:\s+"[0-9a-f]+",\n\s+intel: "[0-9a-f]+"',
+    'sha256 arm:   "{arm}",\n         intel: "{intel}"'.format(
+        arm=os.environ["ARM64_SHA"],
+        intel=os.environ["INTEL_SHA"],
+    ),
+    content,
+    count=1,
+)
+
+cask_path.write_text(content, encoding="utf-8")
+PY
+
+echo "Updated $CASK_PATH to version $VERSION"


### PR DESCRIPTION
## Summary
- add Homebrew install commands to the Chinese and English README files
- point users to `thedavidweng/homebrew-tap` for `brew install --cask pixiv-swiftui`

## Notes
- no CI, release, or packaging changes are included in this PR
- the Homebrew tap is maintained separately on my side and syncs with your existing GitHub Releases
- from your side, this PR only needs the README change if you are comfortable linking the tap
