### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ cd Pixiv-SwiftUI
 sudo xattr -rd com.apple.quarantine /Applications/Pixiv-SwiftUI.app
 ```
 
+- macOS (Homebrew)：
+
+```shell
+brew tap thedavidweng/homebrew-tap
+brew install --cask pixiv-swiftui
+```
+
 ## 特别鸣谢
 
 - [pixez-flutter](https://github.com/Notsfsssf/pixez-flutter): 这是本项目的主要参考对象，大量参考了该项目的 API 和 UI 设计。pixez-flutter 是一个非常优秀的项目，遗憾的是在 iOS 设备上的异常发热问题长期未获得解决，这也是本项目诞生的主要动机。

--- a/README_en.md
+++ b/README_en.md
@@ -99,6 +99,13 @@ Current Support:
 sudo xattr -rd com.apple.quarantine /Applications/Pixiv-SwiftUI.app
 ```
 
+- macOS (Homebrew):
+
+```shell
+brew tap thedavidweng/homebrew-tap
+brew install --cask pixiv-swiftui
+```
+
 ## Special Thanks
 
 - [pixez-flutter](https://github.com/Notsfsssf/pixez-flutter): This project is the main reference, with many API and UI designs referenced from it. pixez-flutter is an excellent project. Unfortunately, the abnormal heating issue on iOS devices remained unresolved for a long time, which was the main motivation for this project.


### PR DESCRIPTION
## Summary
- add Homebrew install commands to the Chinese and English README files
- point users to `thedavidweng/homebrew-tap` for `brew install --cask pixiv-swiftui`

## Notes
- no CI, release, or packaging changes are included in this PR
- the Homebrew tap is maintained separately on my side and syncs with your existing GitHub Releases
- from your side, this PR only needs the README change if you are comfortable linking the tap
