### PR TITLE
Localization of Content type / Visibility filter

### DIFF
--- a/Pixiv-SwiftUI/Core/State/Stores/BookmarkCacheStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/BookmarkCacheStore.swift
@@ -8,6 +8,14 @@ enum BookmarkCacheFilter: String, CaseIterable {
     case all = "全部"
     case normal = "正常"
     case deleted = "已删除"
+
+    var localizedName: String {
+        switch self {
+        case .all: return String(localized: "全部")
+        case .normal: return String(localized: "正常")
+        case .deleted: return String(localized: "已删除")
+        }
+    }
 }
 
 /// 全量同步状态

--- a/Pixiv-SwiftUI/Features/Bookmark/BookmarksPage.swift
+++ b/Pixiv-SwiftUI/Features/Bookmark/BookmarksPage.swift
@@ -121,7 +121,7 @@ ScrollView {
                                 Image(systemName: "bookmark.slash")
                                     .font(.largeTitle)
                                     .foregroundColor(.gray)
-                                Text("暂无收藏")
+                                Text(String(localized: "暂无收藏"))
                                     .foregroundColor(.gray)
                             }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -200,7 +200,7 @@ ScrollView {
                     await store.refreshBookmarks(userId: accountStore.currentAccount?.userId ?? "")
                 }
             }
-            .navigationTitle(initialRestrict == nil ? "收藏" : (initialRestrict == "public" ? "公开收藏" : "非公开收藏"))
+            .navigationTitle(initialRestrict == nil ? String(localized: "收藏") : (initialRestrict == "public" ? String(localized: "公开收藏") : String(localized: "非公开收藏")))
             .pixivNavigationDestinations()
             .onChange(of: accountStore.navigationRequest) { _, newValue in
                 if let request = newValue {
@@ -362,18 +362,18 @@ struct BookmarksNotLoggedInView: View {
                 .foregroundStyle(.secondary)
 
             VStack(spacing: 8) {
-                Text("登录后查看收藏")
+                Text(String(localized: "登录后查看收藏"))
                     .font(.title2)
                     .fontWeight(.semibold)
 
-                Text("收藏喜欢的作品，随时随地浏览")
+                Text(String(localized: "收藏喜欢的作品，随时随地浏览"))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
             }
 
             Button(action: onLogin) {
-                Text("立即登录")
+                Text(String(localized: "立即登录"))
                     .frame(maxWidth: 200)
             }
             .buttonStyle(.borderedProminent)

--- a/Pixiv-SwiftUI/Features/User/FollowingListView.swift
+++ b/Pixiv-SwiftUI/Features/User/FollowingListView.swift
@@ -57,7 +57,7 @@ struct FollowingListView: View {
                 isRefreshing = false
             }
         }
-        .navigationTitle("关注")
+        .navigationTitle(String(localized: "关注"))
         .sensoryFeedback(.impact(weight: .medium), trigger: isRefreshing)
         .toolbar {
             ToolbarItem {

--- a/Pixiv-SwiftUI/Shared/Components/UI/Misc/TypeFilterButton.swift
+++ b/Pixiv-SwiftUI/Shared/Components/UI/Misc/TypeFilterButton.swift
@@ -5,6 +5,14 @@ struct TypeFilterButton: View {
         case all = "全部"
         case illust = "插画"
         case manga = "漫画"
+
+        var localizedName: String {
+            switch self {
+            case .all: return String(localized: "全部")
+            case .illust: return String(localized: "插画")
+            case .manga: return String(localized: "漫画")
+            }
+        }
     }
 
     @Binding var selectedType: ContentType
@@ -17,6 +25,13 @@ struct TypeFilterButton: View {
     enum RestrictType: String, CaseIterable {
         case publicAccess = "公开"
         case privateAccess = "非公开"
+
+        var localizedName: String {
+            switch self {
+            case .publicAccess: return String(localized: "公开")
+            case .privateAccess: return String(localized: "非公开")
+            }
+        }
     }
 
     private var visibleTypes: [ContentType] {
@@ -32,13 +47,13 @@ struct TypeFilterButton: View {
     var body: some View {
         Menu {
             if !visibleTypes.isEmpty {
-                Section("内容类型") {
+                Section(String(localized: "内容类型")) {
                     ForEach(visibleTypes, id: \.self) { type in
                         Button {
                             selectedType = type
                         } label: {
                             HStack {
-                                Text(type.rawValue)
+                                Text(type.localizedName)
                                 if selectedType == type {
                                     Image(systemName: "checkmark")
                                 }
@@ -49,13 +64,13 @@ struct TypeFilterButton: View {
             }
 
             if restrict != nil {
-                Section("可见性") {
+                Section(String(localized: "可见性")) {
                     ForEach(RestrictType.allCases, id: \.self) { restrictType in
                         Button {
                             selectedRestrict = restrictType
                         } label: {
                             HStack {
-                                Text(restrictType.rawValue)
+                                Text(restrictType.localizedName)
                                 if selectedRestrict == restrictType {
                                     Image(systemName: "checkmark")
                                 }
@@ -66,13 +81,13 @@ struct TypeFilterButton: View {
             }
 
             if cacheFilter != nil {
-                Section("缓存状态") {
+                Section(String(localized: "缓存状态")) {
                     ForEach(BookmarkCacheFilter.allCases, id: \.self) { filter in
                         Button {
                             cacheFilter = filter
                         } label: {
                             HStack {
-                                Text(filter.rawValue)
+                                Text(filter.localizedName)
                                 if cacheFilter == filter {
                                     Image(systemName: "checkmark")
                                 }


### PR DESCRIPTION
I been using this app for a while now. But saw in Home page, and Likes page that options for content type, and visibility still hard-coded in Chinese. I try to help make them localized but they'll already translated so just change in Swift and should be good to go.