### PR TITLE
Decoupled isolated bookmark state and mutate bookmark changes to root model

### DIFF
--- a/Pixiv-SwiftUI/Features/Settings/BrowseHistoryView.swift
+++ b/Pixiv-SwiftUI/Features/Settings/BrowseHistoryView.swift
@@ -369,8 +369,6 @@ struct BrowseHistoryCard: View {
     let illust: Illusts
     let columnWidth: CGFloat
 
-    @State private var isBookmarked: Bool
-
     private var isR18: Bool {
         return illust.xRestrict == 1
     }
@@ -413,7 +411,7 @@ struct BrowseHistoryCard: View {
     }
 
     private var bookmarkIconName: String {
-        if !isBookmarked {
+        if !illust.isBookmarked {
             return "heart"
         }
         return illust.bookmarkRestrict == "private" ? "heart.slash.fill" : "heart.fill"
@@ -422,7 +420,6 @@ struct BrowseHistoryCard: View {
     init(illust: Illusts, columnWidth: CGFloat) {
         self.illust = illust
         self.columnWidth = columnWidth
-        _isBookmarked = State(initialValue: illust.isBookmarked)
     }
 
     var body: some View {
@@ -496,11 +493,11 @@ struct BrowseHistoryCard: View {
 
                         Button(action: toggleBookmark) {
                             Image(systemName: bookmarkIconName)
-                                .foregroundColor(isBookmarked ? .red : .secondary)
+                                .foregroundColor(illust.isBookmarked ? .red : .secondary)
                                 .font(.system(size: 14))
                         }
                         .buttonStyle(.plain)
-                        .sensoryFeedback(.impact(weight: .light), trigger: isBookmarked)
+                        .sensoryFeedback(.impact(weight: .light), trigger: illust.isBookmarked)
                     }
                 }
                 .padding(8)
@@ -516,13 +513,13 @@ struct BrowseHistoryCard: View {
     }
 
     private func toggleBookmark() {
-        let wasBookmarked = isBookmarked
+        let wasBookmarked = illust.isBookmarked
         let illustId = illust.id
         let defaultIsPrivate = userSettingStore.userSetting.defaultPrivateLike
         let originalBookmarkRestrict = illust.bookmarkRestrict
         let originalTotalBookmarks = illust.totalBookmarks
 
-        isBookmarked.toggle()
+        illust.isBookmarked.toggle()
         if wasBookmarked {
             illust.totalBookmarks -= 1
             illust.bookmarkRestrict = nil
@@ -540,7 +537,7 @@ struct BrowseHistoryCard: View {
                 }
             } catch {
                 await MainActor.run {
-                    isBookmarked = wasBookmarked
+                    illust.isBookmarked = wasBookmarked
                     illust.totalBookmarks = originalTotalBookmarks
                     illust.bookmarkRestrict = originalBookmarkRestrict
                 }

--- a/Pixiv-SwiftUI/Shared/Components/Cards/BookmarkCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/BookmarkCard.swift
@@ -14,8 +14,6 @@ struct BookmarkCard: View {
     var isDeleted: Bool = false
     var cacheStatus: BookmarkCacheStatus = .none
 
-    @State private var isBookmarked: Bool = false
-
     init(
         illust: Illusts,
         columnCount: Int = 2,
@@ -30,7 +28,6 @@ struct BookmarkCard: View {
         self.expiration = expiration
         self.isDeleted = isDeleted
         self.cacheStatus = cacheStatus
-        _isBookmarked = State(initialValue: illust.isBookmarked)
     }
 
     private var isR18: Bool {
@@ -53,7 +50,7 @@ struct BookmarkCard: View {
     }
 
     private var bookmarkIconName: String {
-        if !isBookmarked {
+        if !illust.isBookmarked {
             return "heart"
         }
         return illust.bookmarkRestrict == "private" ? "heart.slash.fill" : "heart.fill"
@@ -174,18 +171,18 @@ struct BookmarkCard: View {
 
                 if !isDeleted {
                     Button(action: {
-                        if isBookmarked {
+                        if illust.isBookmarked {
                             toggleBookmark(forceUnbookmark: true)
                         } else {
                             toggleBookmark(isPrivate: userSettingStore.userSetting.defaultPrivateLike)
                         }
                     }) {
                         Image(systemName: bookmarkIconName)
-                            .foregroundColor(isBookmarked ? themeManager.currentColor : .secondary)
+                            .foregroundColor(illust.isBookmarked ? themeManager.currentColor : .secondary)
                             .font(.system(size: 20))
                     }
                     .buttonStyle(.plain)
-                    .sensoryFeedback(.impact(weight: .light), trigger: isBookmarked)
+                    .sensoryFeedback(.impact(weight: .light), trigger: illust.isBookmarked)
                 }
             }
             .padding(8)
@@ -213,7 +210,7 @@ struct BookmarkCard: View {
                 Divider()
                 #endif
 
-                if isBookmarked {
+                if illust.isBookmarked {
                     if illust.bookmarkRestrict == "private" {
                         Button {
                             toggleBookmark(isPrivate: false)
@@ -324,19 +321,19 @@ struct BookmarkCard: View {
     }
 
     private func toggleBookmark(isPrivate: Bool = false, forceUnbookmark: Bool = false) {
-        let wasBookmarked = isBookmarked
+        let wasBookmarked = illust.isBookmarked
         let illustId = illust.id
         let originalTotalBookmarks = illust.totalBookmarks
         let originalBookmarkRestrict = illust.bookmarkRestrict
 
         if forceUnbookmark && wasBookmarked {
-            isBookmarked = false
+            illust.isBookmarked = false
             illust.totalBookmarks -= 1
             illust.bookmarkRestrict = nil
         } else if wasBookmarked {
             illust.bookmarkRestrict = isPrivate ? "private" : "public"
         } else {
-            isBookmarked = true
+            illust.isBookmarked = true
             illust.totalBookmarks += 1
             illust.bookmarkRestrict = isPrivate ? "private" : "public"
         }
@@ -415,7 +412,7 @@ struct BookmarkCard: View {
                 }
             } catch {
                 await MainActor.run {
-                    isBookmarked = wasBookmarked
+                    illust.isBookmarked = wasBookmarked
                     illust.totalBookmarks = originalTotalBookmarks
                     illust.bookmarkRestrict = originalBookmarkRestrict
                 }

--- a/Pixiv-SwiftUI/Shared/Components/Cards/IllustCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/IllustCard.swift
@@ -16,8 +16,6 @@ struct IllustCard: View {
     var expiration: CacheExpiration?
     var showsBookmarkCount: Bool
 
-    @State private var isBookmarked: Bool = false
-
     init(
         illust: Illusts,
         columnCount: Int = 2,
@@ -30,7 +28,6 @@ struct IllustCard: View {
         self.columnWidth = columnWidth
         self.expiration = expiration
         self.showsBookmarkCount = showsBookmarkCount
-        _isBookmarked = State(initialValue: illust.isBookmarked)
     }
 
     private var isR18: Bool {
@@ -54,7 +51,7 @@ struct IllustCard: View {
 
     /// 获取收藏图标，根据收藏状态和类型返回不同的图标
     private var bookmarkIconName: String {
-        if !isBookmarked {
+        if !illust.isBookmarked {
             return "heart"
         }
         return illust.bookmarkRestrict == "private" ? "heart.slash.fill" : "heart.fill"
@@ -169,18 +166,18 @@ struct IllustCard: View {
                 Spacer()
 
                 Button {
-                    if isBookmarked {
+                    if illust.isBookmarked {
                         toggleBookmark(forceUnbookmark: true)
                     } else {
                         toggleBookmark(isPrivate: userSettingStore.userSetting.defaultPrivateLike)
                     }
                 } label: {
                     Image(systemName: bookmarkIconName)
-                        .foregroundColor(isBookmarked ? themeManager.currentColor : .secondary)
+                        .foregroundColor(illust.isBookmarked ? themeManager.currentColor : .secondary)
                         .font(.system(size: 20))
                 }
                 .buttonStyle(.plain)
-                .sensoryFeedback(.impact(weight: .light), trigger: isBookmarked)
+                .sensoryFeedback(.impact(weight: .light), trigger: illust.isBookmarked)
             }
             .padding(8)
         }
@@ -203,7 +200,7 @@ struct IllustCard: View {
             Divider()
             #endif
 
-            if isBookmarked {
+            if illust.isBookmarked {
                 if illust.bookmarkRestrict == "private" {
                     Button {
                         toggleBookmark(isPrivate: false)
@@ -277,19 +274,19 @@ struct IllustCard: View {
     }
 
     private func toggleBookmark(isPrivate: Bool = false, forceUnbookmark: Bool = false) {
-        let wasBookmarked = isBookmarked
+        let wasBookmarked = illust.isBookmarked
         let illustId = illust.id
         let originalTotalBookmarks = illust.totalBookmarks
         let originalBookmarkRestrict = illust.bookmarkRestrict
 
         if forceUnbookmark && wasBookmarked {
-            isBookmarked = false
+            illust.isBookmarked = false
             illust.totalBookmarks -= 1
             illust.bookmarkRestrict = nil
         } else if wasBookmarked {
             illust.bookmarkRestrict = isPrivate ? "private" : "public"
         } else {
-            isBookmarked = true
+            illust.isBookmarked = true
             illust.totalBookmarks += 1
             illust.bookmarkRestrict = isPrivate ? "private" : "public"
         }
@@ -349,7 +346,7 @@ struct IllustCard: View {
                 }
             } catch {
                 await MainActor.run {
-                    isBookmarked = wasBookmarked
+                    illust.isBookmarked = wasBookmarked
                     illust.totalBookmarks = originalTotalBookmarks
                     illust.bookmarkRestrict = originalBookmarkRestrict
                 }

--- a/Pixiv-SwiftUI/Shared/Components/Cards/IllustSeriesCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/IllustSeriesCard.swift
@@ -5,12 +5,9 @@ struct IllustSeriesCard: View {
     let illust: Illusts
     let index: Int
 
-    @State private var isBookmarked: Bool = false
-
     init(illust: Illusts, index: Int) {
         self.illust = illust
         self.index = index
-        _isBookmarked = State(initialValue: illust.isBookmarked)
     }
 
     var body: some View {
@@ -43,9 +40,9 @@ struct IllustSeriesCard: View {
                     }
 
                     HStack(spacing: 4) {
-                        Image(systemName: isBookmarked ? "heart.fill" : "heart")
+                        Image(systemName: illust.isBookmarked ? "heart.fill" : "heart")
                             .font(.caption2)
-                            .foregroundColor(isBookmarked ? .red : .secondary)
+                            .foregroundColor(illust.isBookmarked ? .red : .secondary)
                         Text(NumberFormatter.formatCount(illust.totalBookmarks))
                             .font(.caption)
                     }

--- a/Pixiv-SwiftUI/Shared/Components/Cards/RelatedIllustCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/RelatedIllustCard.swift
@@ -15,14 +15,11 @@ struct RelatedIllustCard: View {
     let columnWidth: CGFloat?
     let onTap: (() -> Void)?
 
-    @State private var isBookmarked: Bool = false
-
     init(illust: Illusts, showTitle: Bool = true, columnWidth: CGFloat? = nil, onTap: (() -> Void)? = nil) {
         self.illust = illust
         self.showTitle = showTitle
         self.columnWidth = columnWidth
         self.onTap = onTap
-        _isBookmarked = State(initialValue: illust.isBookmarked)
     }
 
     private var isR18: Bool {
@@ -172,7 +169,7 @@ struct RelatedIllustCard: View {
                 Divider()
                 #endif
 
-                if isBookmarked {
+                if illust.isBookmarked {
                     if illust.bookmarkRestrict == "private" {
                         Button {
                             toggleBookmark(isPrivate: false)
@@ -247,17 +244,17 @@ struct RelatedIllustCard: View {
     }
 
     private func toggleBookmark(isPrivate: Bool = false, forceUnbookmark: Bool = false) {
-        let wasBookmarked = isBookmarked
+        let wasBookmarked = illust.isBookmarked
         let illustId = illust.id
 
         if forceUnbookmark && wasBookmarked {
-            isBookmarked = false
+            illust.isBookmarked = false
             illust.totalBookmarks -= 1
             illust.bookmarkRestrict = nil
         } else if wasBookmarked {
             illust.bookmarkRestrict = isPrivate ? "private" : "public"
         } else {
-            isBookmarked = true
+            illust.isBookmarked = true
             illust.totalBookmarks += 1
             illust.bookmarkRestrict = isPrivate ? "private" : "public"
         }
@@ -318,13 +315,13 @@ struct RelatedIllustCard: View {
             } catch {
                 await MainActor.run {
                     if forceUnbookmark && wasBookmarked {
-                        isBookmarked = true
+                        illust.isBookmarked = true
                         illust.totalBookmarks += 1
                         illust.bookmarkRestrict = "public"
                     } else if wasBookmarked {
                         illust.bookmarkRestrict = wasBookmarked ? "public" : nil
                     } else {
-                        isBookmarked = false
+                        illust.isBookmarked = false
                         illust.totalBookmarks -= 1
                         illust.bookmarkRestrict = nil
                     }


### PR DESCRIPTION
tl;dr fix problem where user tap like button on illustration, and when navigate back to list of illusts like state does not reflect with latest state

in short i saw that bookmark like status are living in `@State` directive but does not used for anything else. this implementation move mutation to root model so when we navigate back we see so called "optimistic" updated state

https://github.com/user-attachments/assets/ea1eb85e-87aa-40e4-80e0-d04589189d01
