### PR TITLE
fix(icon): resolve dim colors in tinted mode

### DIFF
--- a/Pixiv-SwiftUI/AppIcon.icon/icon.json
+++ b/Pixiv-SwiftUI/AppIcon.icon/icon.json
@@ -53,7 +53,23 @@
               "value" : "normal"
             }
           ],
-          "glass" : true,
+          "fill-specializations" : [
+            {
+              "appearance" : "tinted",
+              "value" : {
+                "solid" : "srgb:1.00000,1.00000,1.00000,1.00000"
+              }
+            }
+          ],
+          "glass-specializations" : [
+            {
+              "value" : true
+            },
+            {
+              "appearance" : "tinted",
+              "value" : true
+            }
+          ],
           "hidden" : false,
           "image-name" : "AppIcon_1024 2.png",
           "name" : "AppIcon_1024 2"


### PR DESCRIPTION
解决 Tint 模式下图标颜色暗淡的问题
系统将图标亮度作为染色基准，蓝色在灰度转换中亮度较低
<img width="1283" height="716" alt="image" src="https://github.com/user-attachments/assets/2041dc2f-c119-4b12-b90f-2f7ad4ab8987" />
修改前
<img width="579" height="579" alt="IMG_5800" src="https://github.com/user-attachments/assets/56858631-bd54-43cc-ae6a-4b1c83902987" />
