### PR TITLE
feat: add local keyword blocking for novels

### DIFF
--- a/Pixiv-SwiftUI/Core/DataModels/Domain/UserSetting.swift
+++ b/Pixiv-SwiftUI/Core/DataModels/Domain/UserSetting.swift
@@ -168,6 +168,15 @@ final class UserSetting: Codable {
     /// 屏蔽的小说ID列表（仅存储ID，用于过滤）
     var blockedNovels: [Int] = []
 
+    /// 按小说标题屏蔽的关键字
+    var blockedNovelTitleKeywords: [String] = []
+
+    /// 按小说系列屏蔽的关键字
+    var blockedNovelSeriesKeywords: [String] = []
+
+    /// 按小说简介屏蔽的关键字
+    var blockedNovelCaptionKeywords: [String] = []
+
     /// 屏蔽标签的详细信息
     var blockedTagInfos: [BlockedTagInfo] = []
 
@@ -344,9 +353,14 @@ final class UserSetting: Codable {
         case blockedTags
         case blockedUsers
         case blockedIllusts
+        case blockedNovels
+        case blockedNovelTitleKeywords
+        case blockedNovelSeriesKeywords
+        case blockedNovelCaptionKeywords
         case blockedTagInfos
         case blockedUserInfos
         case blockedIllustInfos
+        case blockedNovelInfos
         case translateServiceId
         case translateTargetLanguage
         case translateOpenAIApiKey
@@ -449,6 +463,10 @@ final class UserSetting: Codable {
         self.blockedTags = try container.decodeIfPresent([String].self, forKey: .blockedTags) ?? []
         self.blockedUsers = try container.decodeIfPresent([String].self, forKey: .blockedUsers) ?? []
         self.blockedIllusts = try container.decodeIfPresent([Int].self, forKey: .blockedIllusts) ?? []
+        self.blockedNovels = try container.decodeIfPresent([Int].self, forKey: .blockedNovels) ?? []
+        self.blockedNovelTitleKeywords = try container.decodeIfPresent([String].self, forKey: .blockedNovelTitleKeywords) ?? []
+        self.blockedNovelSeriesKeywords = try container.decodeIfPresent([String].self, forKey: .blockedNovelSeriesKeywords) ?? []
+        self.blockedNovelCaptionKeywords = try container.decodeIfPresent([String].self, forKey: .blockedNovelCaptionKeywords) ?? []
         self.blockedTagInfos = (try container.decodeIfPresent([BlockedTagInfoData].self, forKey: .blockedTagInfos) ?? []).map { data in
             let info = BlockedTagInfo(name: data.name, translatedName: data.translatedName)
             return info
@@ -459,6 +477,10 @@ final class UserSetting: Codable {
         }
         self.blockedIllustInfos = (try container.decodeIfPresent([BlockedIllustInfoData].self, forKey: .blockedIllustInfos) ?? []).map { data in
             let info = BlockedIllustInfo(illustId: data.illustId, title: data.title, authorId: data.authorId, authorName: data.authorName, thumbnailUrl: data.thumbnailUrl)
+            return info
+        }
+        self.blockedNovelInfos = (try container.decodeIfPresent([BlockedNovelInfoData].self, forKey: .blockedNovelInfos) ?? []).map { data in
+            let info = BlockedNovelInfo(novelId: data.novelId, title: data.title, authorId: data.authorId, authorName: data.authorName, thumbnailUrl: data.thumbnailUrl)
             return info
         }
         self.translateServiceId = try container.decodeIfPresent(String.self, forKey: .translateServiceId) ?? "google"
@@ -552,9 +574,14 @@ final class UserSetting: Codable {
         try container.encode(blockedTags, forKey: .blockedTags)
         try container.encode(blockedUsers, forKey: .blockedUsers)
         try container.encode(blockedIllusts, forKey: .blockedIllusts)
+        try container.encode(blockedNovels, forKey: .blockedNovels)
+        try container.encode(blockedNovelTitleKeywords, forKey: .blockedNovelTitleKeywords)
+        try container.encode(blockedNovelSeriesKeywords, forKey: .blockedNovelSeriesKeywords)
+        try container.encode(blockedNovelCaptionKeywords, forKey: .blockedNovelCaptionKeywords)
         try container.encode(blockedTagInfos.map { BlockedTagInfoData(name: $0.name, translatedName: $0.translatedName) }, forKey: .blockedTagInfos)
         try container.encode(blockedUserInfos.map { BlockedUserInfoData(userId: $0.userId, name: $0.name, account: $0.account, avatarUrl: $0.avatarUrl) }, forKey: .blockedUserInfos)
         try container.encode(blockedIllustInfos.map { BlockedIllustInfoData(illustId: $0.illustId, title: $0.title, authorId: $0.authorId, authorName: $0.authorName, thumbnailUrl: $0.thumbnailUrl) }, forKey: .blockedIllustInfos)
+        try container.encode(blockedNovelInfos.map { BlockedNovelInfoData(novelId: $0.novelId, title: $0.title, authorId: $0.authorId, authorName: $0.authorName, thumbnailUrl: $0.thumbnailUrl) }, forKey: .blockedNovelInfos)
         try container.encode(translateServiceId, forKey: .translateServiceId)
         try container.encode(translateTargetLanguage, forKey: .translateTargetLanguage)
         try container.encodeIfPresent(translateOpenAIApiKey, forKey: .translateOpenAIApiKey)
@@ -606,6 +633,14 @@ struct BlockedUserInfoData: Codable {
 
 struct BlockedIllustInfoData: Codable {
     var illustId: Int
+    var title: String?
+    var authorId: String?
+    var authorName: String?
+    var thumbnailUrl: String?
+}
+
+struct BlockedNovelInfoData: Codable {
+    var novelId: Int
     var title: String?
     var authorId: String?
     var authorName: String?

--- a/Pixiv-SwiftUI/Core/DataModels/Export/ExportFormat.swift
+++ b/Pixiv-SwiftUI/Core/DataModels/Export/ExportFormat.swift
@@ -83,11 +83,48 @@ struct MuteDataExport: Codable {
     let banTags: [BanTagItem]
     let banUserIds: [BanUserIdItem]
     let banIllustIds: [BanIllustIdItem]
+    let banNovelIds: [BanNovelIdItem]
+    let banNovelTitleKeywords: [String]
+    let banNovelSeriesKeywords: [String]
+    let banNovelCaptionKeywords: [String]
+
+    init(
+        banTags: [BanTagItem],
+        banUserIds: [BanUserIdItem],
+        banIllustIds: [BanIllustIdItem],
+        banNovelIds: [BanNovelIdItem] = [],
+        banNovelTitleKeywords: [String] = [],
+        banNovelSeriesKeywords: [String] = [],
+        banNovelCaptionKeywords: [String] = []
+    ) {
+        self.banTags = banTags
+        self.banUserIds = banUserIds
+        self.banIllustIds = banIllustIds
+        self.banNovelIds = banNovelIds
+        self.banNovelTitleKeywords = banNovelTitleKeywords
+        self.banNovelSeriesKeywords = banNovelSeriesKeywords
+        self.banNovelCaptionKeywords = banNovelCaptionKeywords
+    }
 
     enum CodingKeys: String, CodingKey {
         case banTags = "ban_tags"
         case banUserIds = "ban_user_ids"
         case banIllustIds = "ban_illust_ids"
+        case banNovelIds = "ban_novel_ids"
+        case banNovelTitleKeywords = "ban_novel_title_keywords"
+        case banNovelSeriesKeywords = "ban_novel_series_keywords"
+        case banNovelCaptionKeywords = "ban_novel_caption_keywords"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.banTags = try container.decodeIfPresent([BanTagItem].self, forKey: .banTags) ?? []
+        self.banUserIds = try container.decodeIfPresent([BanUserIdItem].self, forKey: .banUserIds) ?? []
+        self.banIllustIds = try container.decodeIfPresent([BanIllustIdItem].self, forKey: .banIllustIds) ?? []
+        self.banNovelIds = try container.decodeIfPresent([BanNovelIdItem].self, forKey: .banNovelIds) ?? []
+        self.banNovelTitleKeywords = try container.decodeIfPresent([String].self, forKey: .banNovelTitleKeywords) ?? []
+        self.banNovelSeriesKeywords = try container.decodeIfPresent([String].self, forKey: .banNovelSeriesKeywords) ?? []
+        self.banNovelCaptionKeywords = try container.decodeIfPresent([String].self, forKey: .banNovelCaptionKeywords) ?? []
     }
 }
 
@@ -117,6 +154,16 @@ struct BanIllustIdItem: Codable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case illustId = "illust_id"
+        case name
+    }
+}
+
+struct BanNovelIdItem: Codable, Sendable {
+    let novelId: Int
+    let name: String?
+
+    enum CodingKeys: String, CodingKey {
+        case novelId = "novel_id"
         case name
     }
 }

--- a/Pixiv-SwiftUI/Core/DataModels/Export/FlutterCompat.swift
+++ b/Pixiv-SwiftUI/Core/DataModels/Export/FlutterCompat.swift
@@ -132,6 +132,26 @@ struct FlutterCompat {
             )
         }
 
-        return MuteDataExport(banTags: banTags, banUserIds: banUserIds, banIllustIds: banIllustIds)
+        let banNovelIds: [BanNovelIdItem] = (json["ban_novel_ids"] as? [[String: Any]] ?? []).compactMap { item in
+            guard let novelId = item["novel_id"] as? Int ?? item["novelId"] as? Int else { return nil }
+            return BanNovelIdItem(
+                novelId: novelId,
+                name: item["name"] as? String
+            )
+        }
+
+        let banNovelTitleKeywords = json["ban_novel_title_keywords"] as? [String] ?? []
+        let banNovelSeriesKeywords = json["ban_novel_series_keywords"] as? [String] ?? []
+        let banNovelCaptionKeywords = json["ban_novel_caption_keywords"] as? [String] ?? []
+
+        return MuteDataExport(
+            banTags: banTags,
+            banUserIds: banUserIds,
+            banIllustIds: banIllustIds,
+            banNovelIds: banNovelIds,
+            banNovelTitleKeywords: banNovelTitleKeywords,
+            banNovelSeriesKeywords: banNovelSeriesKeywords,
+            banNovelCaptionKeywords: banNovelCaptionKeywords
+        )
     }
 }

--- a/Pixiv-SwiftUI/Core/Services/DataExportService.swift
+++ b/Pixiv-SwiftUI/Core/Services/DataExportService.swift
@@ -108,31 +108,38 @@ final class DataExportService {
     }
 
     func exportMuteData() async throws -> URL {
-        let context = dataContainer.mainContext
+        let banTagItems = if userSettingStore.blockedTagInfos.isEmpty {
+            userSettingStore.blockedTags.map { BanTagItem(name: $0, translatedName: nil) }
+        } else {
+            userSettingStore.blockedTagInfos.map { BanTagItem(name: $0.name, translatedName: $0.translatedName) }
+        }
 
-        let banTagDescriptor = FetchDescriptor<BanTag>(
-            predicate: #Predicate { $0.ownerId == currentUserId }
-        )
-        let banTags = try context.fetch(banTagDescriptor)
+        let banUserItems = if userSettingStore.blockedUserInfos.isEmpty {
+            userSettingStore.blockedUsers.map { BanUserIdItem(userId: $0, name: nil) }
+        } else {
+            userSettingStore.blockedUserInfos.map { BanUserIdItem(userId: $0.userId, name: $0.name) }
+        }
 
-        let banUserDescriptor = FetchDescriptor<BanUserId>(
-            predicate: #Predicate { $0.ownerId == currentUserId }
-        )
-        let banUsers = try context.fetch(banUserDescriptor)
+        let banIllustItems = if userSettingStore.blockedIllustInfos.isEmpty {
+            userSettingStore.blockedIllusts.map { BanIllustIdItem(illustId: $0, name: nil) }
+        } else {
+            userSettingStore.blockedIllustInfos.map { BanIllustIdItem(illustId: $0.illustId, name: $0.title) }
+        }
 
-        let banIllustDescriptor = FetchDescriptor<BanIllustId>(
-            predicate: #Predicate { $0.ownerId == currentUserId }
-        )
-        let banIllusts = try context.fetch(banIllustDescriptor)
-
-        let banTagItems = banTags.map { BanTagItem(name: $0.name, translatedName: nil) }
-        let banUserItems = banUsers.map { BanUserIdItem(userId: $0.userId, name: nil) }
-        let banIllustItems = banIllusts.map { BanIllustIdItem(illustId: $0.illustId, name: nil) }
+        let banNovelItems = if userSettingStore.blockedNovelInfos.isEmpty {
+            userSettingStore.blockedNovels.map { BanNovelIdItem(novelId: $0, name: nil) }
+        } else {
+            userSettingStore.blockedNovelInfos.map { BanNovelIdItem(novelId: $0.novelId, name: $0.title) }
+        }
 
         let export = MuteDataExport(
             banTags: banTagItems,
             banUserIds: banUserItems,
-            banIllustIds: banIllustItems
+            banIllustIds: banIllustItems,
+            banNovelIds: banNovelItems,
+            banNovelTitleKeywords: userSettingStore.blockedNovelTitleKeywords,
+            banNovelSeriesKeywords: userSettingStore.blockedNovelSeriesKeywords,
+            banNovelCaptionKeywords: userSettingStore.blockedNovelCaptionKeywords
         )
         let header = ExportHeader(version: 1, type: .muteData, exportedAt: Date())
 
@@ -246,9 +253,25 @@ final class DataExportService {
 
         switch strategy {
         case .merge:
-            try mergeMuteData(banTags: exportData.banTags, banUsers: exportData.banUserIds, banIllusts: exportData.banIllustIds)
+            try mergeMuteData(
+                banTags: exportData.banTags,
+                banUsers: exportData.banUserIds,
+                banIllusts: exportData.banIllustIds,
+                banNovels: exportData.banNovelIds,
+                banNovelTitleKeywords: exportData.banNovelTitleKeywords,
+                banNovelSeriesKeywords: exportData.banNovelSeriesKeywords,
+                banNovelCaptionKeywords: exportData.banNovelCaptionKeywords
+            )
         case .replace:
-            try replaceMuteData(banTags: exportData.banTags, banUsers: exportData.banUserIds, banIllusts: exportData.banIllustIds)
+            try replaceMuteData(
+                banTags: exportData.banTags,
+                banUsers: exportData.banUserIds,
+                banIllusts: exportData.banIllustIds,
+                banNovels: exportData.banNovelIds,
+                banNovelTitleKeywords: exportData.banNovelTitleKeywords,
+                banNovelSeriesKeywords: exportData.banNovelSeriesKeywords,
+                banNovelCaptionKeywords: exportData.banNovelCaptionKeywords
+            )
         case .cancel:
             throw DataExportError.cancelled
         }
@@ -370,7 +393,15 @@ final class DataExportService {
         }
     }
 
-    private func mergeMuteData(banTags: [BanTagItem], banUsers: [BanUserIdItem], banIllusts: [BanIllustIdItem]) throws {
+    private func mergeMuteData(
+        banTags: [BanTagItem],
+        banUsers: [BanUserIdItem],
+        banIllusts: [BanIllustIdItem],
+        banNovels: [BanNovelIdItem],
+        banNovelTitleKeywords: [String],
+        banNovelSeriesKeywords: [String],
+        banNovelCaptionKeywords: [String]
+    ) throws {
         let context = dataContainer.mainContext
         let uid = currentUserId
 
@@ -408,10 +439,47 @@ final class DataExportService {
         }
 
         try context.save()
+
+        for tag in banTags {
+            try userSettingStore.addBlockedTagWithInfo(tag.name, translatedName: tag.translatedName)
+        }
+
+        for user in banUsers {
+            try userSettingStore.addBlockedUserWithInfo(user.userId, name: user.name, account: nil, avatarUrl: nil)
+        }
+
+        for illust in banIllusts {
+            try userSettingStore.addBlockedIllustWithInfo(illust.illustId, title: illust.name, authorId: nil, authorName: nil, thumbnailUrl: nil)
+        }
+
+        for novel in banNovels {
+            try userSettingStore.addBlockedNovelWithInfo(novel.novelId, title: novel.name, authorId: nil, authorName: nil, thumbnailUrl: nil)
+        }
+
+        for keyword in banNovelTitleKeywords {
+            try userSettingStore.addBlockedNovelTitleKeyword(keyword)
+        }
+
+        for keyword in banNovelSeriesKeywords {
+            try userSettingStore.addBlockedNovelSeriesKeyword(keyword)
+        }
+
+        for keyword in banNovelCaptionKeywords {
+            try userSettingStore.addBlockedNovelCaptionKeyword(keyword)
+        }
+
         userSettingStore.loadUserSetting()
     }
 
-    private func replaceMuteData(banTags: [BanTagItem], banUsers: [BanUserIdItem], banIllusts: [BanIllustIdItem]) throws {
+    private func replaceMuteData(
+        banTags: [BanTagItem],
+        banUsers: [BanUserIdItem],
+        banIllusts: [BanIllustIdItem],
+        banNovels: [BanNovelIdItem],
+        banNovelTitleKeywords: [String],
+        banNovelSeriesKeywords: [String],
+        banNovelCaptionKeywords: [String]
+    ) throws {
         let context = dataContainer.mainContext
         let uid = currentUserId
 
@@ -436,6 +504,58 @@ final class DataExportService {
         }
 
         try context.save()
+        userSettingStore.blockedTags = []
+        userSettingStore.userSetting.blockedTags = []
+        userSettingStore.blockedUsers = []
+        userSettingStore.userSetting.blockedUsers = []
+        userSettingStore.blockedIllusts = []
+        userSettingStore.userSetting.blockedIllusts = []
+        userSettingStore.blockedNovels = []
+        userSettingStore.userSetting.blockedNovels = []
+        userSettingStore.blockedTagInfos = []
+        userSettingStore.userSetting.blockedTagInfos = []
+        userSettingStore.blockedUserInfos = []
+        userSettingStore.userSetting.blockedUserInfos = []
+        userSettingStore.blockedIllustInfos = []
+        userSettingStore.userSetting.blockedIllustInfos = []
+        userSettingStore.blockedNovelInfos = []
+        userSettingStore.userSetting.blockedNovelInfos = []
+        userSettingStore.blockedNovelTitleKeywords = []
+        userSettingStore.userSetting.blockedNovelTitleKeywords = []
+        userSettingStore.blockedNovelSeriesKeywords = []
+        userSettingStore.userSetting.blockedNovelSeriesKeywords = []
+        userSettingStore.blockedNovelCaptionKeywords = []
+        userSettingStore.userSetting.blockedNovelCaptionKeywords = []
+        try userSettingStore.saveSetting()
+
+        for tag in banTags {
+            try userSettingStore.addBlockedTagWithInfo(tag.name, translatedName: tag.translatedName)
+        }
+
+        for user in banUsers {
+            try userSettingStore.addBlockedUserWithInfo(user.userId, name: user.name, account: nil, avatarUrl: nil)
+        }
+
+        for illust in banIllusts {
+            try userSettingStore.addBlockedIllustWithInfo(illust.illustId, title: illust.name, authorId: nil, authorName: nil, thumbnailUrl: nil)
+        }
+
+        for novel in banNovels {
+            try userSettingStore.addBlockedNovelWithInfo(novel.novelId, title: novel.name, authorId: nil, authorName: nil, thumbnailUrl: nil)
+        }
+
+        for keyword in banNovelTitleKeywords {
+            try userSettingStore.addBlockedNovelTitleKeyword(keyword)
+        }
+
+        for keyword in banNovelSeriesKeywords {
+            try userSettingStore.addBlockedNovelSeriesKeyword(keyword)
+        }
+
+        for keyword in banNovelCaptionKeywords {
+            try userSettingStore.addBlockedNovelCaptionKeyword(keyword)
+        }
+
         userSettingStore.loadUserSetting()
     }
 }

--- a/Pixiv-SwiftUI/Core/Services/Sync/WebDAVSyncModels.swift
+++ b/Pixiv-SwiftUI/Core/Services/Sync/WebDAVSyncModels.swift
@@ -241,10 +241,68 @@ struct WebDAVSyncMutePayload: Codable, Sendable {
     let blockedUsers: [String]
     let blockedIllusts: [Int]
     let blockedNovels: [Int]
+    let blockedNovelTitleKeywords: [String]
+    let blockedNovelSeriesKeywords: [String]
+    let blockedNovelCaptionKeywords: [String]
     let blockedTagInfos: [WebDAVBlockedTagInfoPayload]
     let blockedUserInfos: [WebDAVBlockedUserInfoPayload]
     let blockedIllustInfos: [WebDAVBlockedIllustInfoPayload]
     let blockedNovelInfos: [WebDAVBlockedNovelInfoPayload]
+
+    init(
+        blockedTags: [String],
+        blockedUsers: [String],
+        blockedIllusts: [Int],
+        blockedNovels: [Int],
+        blockedNovelTitleKeywords: [String] = [],
+        blockedNovelSeriesKeywords: [String] = [],
+        blockedNovelCaptionKeywords: [String] = [],
+        blockedTagInfos: [WebDAVBlockedTagInfoPayload],
+        blockedUserInfos: [WebDAVBlockedUserInfoPayload],
+        blockedIllustInfos: [WebDAVBlockedIllustInfoPayload],
+        blockedNovelInfos: [WebDAVBlockedNovelInfoPayload]
+    ) {
+        self.blockedTags = blockedTags
+        self.blockedUsers = blockedUsers
+        self.blockedIllusts = blockedIllusts
+        self.blockedNovels = blockedNovels
+        self.blockedNovelTitleKeywords = blockedNovelTitleKeywords
+        self.blockedNovelSeriesKeywords = blockedNovelSeriesKeywords
+        self.blockedNovelCaptionKeywords = blockedNovelCaptionKeywords
+        self.blockedTagInfos = blockedTagInfos
+        self.blockedUserInfos = blockedUserInfos
+        self.blockedIllustInfos = blockedIllustInfos
+        self.blockedNovelInfos = blockedNovelInfos
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case blockedTags
+        case blockedUsers
+        case blockedIllusts
+        case blockedNovels
+        case blockedNovelTitleKeywords
+        case blockedNovelSeriesKeywords
+        case blockedNovelCaptionKeywords
+        case blockedTagInfos
+        case blockedUserInfos
+        case blockedIllustInfos
+        case blockedNovelInfos
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.blockedTags = try container.decodeIfPresent([String].self, forKey: .blockedTags) ?? []
+        self.blockedUsers = try container.decodeIfPresent([String].self, forKey: .blockedUsers) ?? []
+        self.blockedIllusts = try container.decodeIfPresent([Int].self, forKey: .blockedIllusts) ?? []
+        self.blockedNovels = try container.decodeIfPresent([Int].self, forKey: .blockedNovels) ?? []
+        self.blockedNovelTitleKeywords = try container.decodeIfPresent([String].self, forKey: .blockedNovelTitleKeywords) ?? []
+        self.blockedNovelSeriesKeywords = try container.decodeIfPresent([String].self, forKey: .blockedNovelSeriesKeywords) ?? []
+        self.blockedNovelCaptionKeywords = try container.decodeIfPresent([String].self, forKey: .blockedNovelCaptionKeywords) ?? []
+        self.blockedTagInfos = try container.decodeIfPresent([WebDAVBlockedTagInfoPayload].self, forKey: .blockedTagInfos) ?? []
+        self.blockedUserInfos = try container.decodeIfPresent([WebDAVBlockedUserInfoPayload].self, forKey: .blockedUserInfos) ?? []
+        self.blockedIllustInfos = try container.decodeIfPresent([WebDAVBlockedIllustInfoPayload].self, forKey: .blockedIllustInfos) ?? []
+        self.blockedNovelInfos = try container.decodeIfPresent([WebDAVBlockedNovelInfoPayload].self, forKey: .blockedNovelInfos) ?? []
+    }
 }
 
 struct WebDAVSyncSearchHistoryPayload: Codable, Sendable {

--- a/Pixiv-SwiftUI/Core/Services/Sync/WebDAVSyncService.swift
+++ b/Pixiv-SwiftUI/Core/Services/Sync/WebDAVSyncService.swift
@@ -92,6 +92,9 @@ final class WebDAVSyncService {
             blockedUsers: userSettingStore.blockedUsers,
             blockedIllusts: userSettingStore.blockedIllusts,
             blockedNovels: userSettingStore.blockedNovels,
+            blockedNovelTitleKeywords: userSettingStore.blockedNovelTitleKeywords,
+            blockedNovelSeriesKeywords: userSettingStore.blockedNovelSeriesKeywords,
+            blockedNovelCaptionKeywords: userSettingStore.blockedNovelCaptionKeywords,
             blockedTagInfos: userSettingStore.blockedTagInfos.map(WebDAVBlockedTagInfoPayload.init),
             blockedUserInfos: userSettingStore.blockedUserInfos.map(WebDAVBlockedUserInfoPayload.init),
             blockedIllustInfos: userSettingStore.blockedIllustInfos.map(WebDAVBlockedIllustInfoPayload.init),
@@ -258,6 +261,9 @@ final class WebDAVSyncService {
         userSettingStore.blockedUsers = payload.blockedUsers
         userSettingStore.blockedIllusts = payload.blockedIllusts
         userSettingStore.blockedNovels = payload.blockedNovels
+        userSettingStore.blockedNovelTitleKeywords = payload.blockedNovelTitleKeywords
+        userSettingStore.blockedNovelSeriesKeywords = payload.blockedNovelSeriesKeywords
+        userSettingStore.blockedNovelCaptionKeywords = payload.blockedNovelCaptionKeywords
         userSettingStore.blockedTagInfos = blockedTagInfos
         userSettingStore.blockedUserInfos = blockedUserInfos
         userSettingStore.blockedIllustInfos = blockedIllustInfos
@@ -267,6 +273,9 @@ final class WebDAVSyncService {
         setting.blockedUsers = payload.blockedUsers
         setting.blockedIllusts = payload.blockedIllusts
         setting.blockedNovels = payload.blockedNovels
+        setting.blockedNovelTitleKeywords = payload.blockedNovelTitleKeywords
+        setting.blockedNovelSeriesKeywords = payload.blockedNovelSeriesKeywords
+        setting.blockedNovelCaptionKeywords = payload.blockedNovelCaptionKeywords
         setting.blockedTagInfos = blockedTagInfos
         setting.blockedUserInfos = blockedUserInfos
         setting.blockedIllustInfos = blockedIllustInfos

--- a/Pixiv-SwiftUI/Core/State/Stores/UserSettingStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/UserSettingStore.swift
@@ -4,48 +4,50 @@ import Observation
 
 let spoilerTags: Set<String> = ["ネタバレ", "spoiler", "ネタバレ注意"]
 
-private func normalizedBlockedKeyword(_ keyword: String) -> String {
-    keyword.trimmingCharacters(in: .whitespacesAndNewlines)
-}
-
-private func containsBlockedKeyword(_ keyword: String, in keywords: [String]) -> Bool {
-    let normalizedKeyword = normalizedBlockedKeyword(keyword)
-    guard !normalizedKeyword.isEmpty else {
-        return false
+private enum NovelKeywordBlockMatcher {
+    static func normalizedKeyword(_ keyword: String) -> String {
+        keyword.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    return keywords.contains {
-        $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
-    }
-}
-
-private func matchesBlockedKeyword(in text: String, keywords: [String]) -> Bool {
-    let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !normalizedText.isEmpty else {
-        return false
-    }
-
-    return keywords.contains { keyword in
-        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+    static func containsKeyword(_ keyword: String, in keywords: [String]) -> Bool {
+        let normalizedKeyword = normalizedKeyword(keyword)
         guard !normalizedKeyword.isEmpty else {
             return false
         }
 
-        return normalizedText.range(of: normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+        return keywords.contains {
+            $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }
     }
-}
 
-private func isNovelBlockedByKeywords(
-    title: String,
-    seriesTitle: String,
-    caption: String,
-    titleKeywords: [String],
-    seriesKeywords: [String],
-    captionKeywords: [String]
-) -> Bool {
-    matchesBlockedKeyword(in: title, keywords: titleKeywords)
-        || matchesBlockedKeyword(in: seriesTitle, keywords: seriesKeywords)
-        || matchesBlockedKeyword(in: caption, keywords: captionKeywords)
+    static func matchesKeyword(in text: String, keywords: [String]) -> Bool {
+        let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedText.isEmpty else {
+            return false
+        }
+
+        return keywords.contains { keyword in
+            let normalizedKeyword = normalizedKeyword(keyword)
+            guard !normalizedKeyword.isEmpty else {
+                return false
+            }
+
+            return normalizedText.range(of: normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+        }
+    }
+
+    static func isNovelBlocked(
+        title: String,
+        seriesTitle: String,
+        caption: String,
+        titleKeywords: [String],
+        seriesKeywords: [String],
+        captionKeywords: [String]
+    ) -> Bool {
+        matchesKeyword(in: title, keywords: titleKeywords)
+            || matchesKeyword(in: seriesTitle, keywords: seriesKeywords)
+            || matchesKeyword(in: caption, keywords: captionKeywords)
+    }
 }
 
 /// 用户设置管理
@@ -617,8 +619,8 @@ final class UserSettingStore {
     }
 
     func addBlockedNovelTitleKeyword(_ keyword: String) throws {
-        let normalizedKeyword = normalizedBlockedKeyword(keyword)
-        guard !normalizedKeyword.isEmpty, !containsBlockedKeyword(normalizedKeyword, in: blockedNovelTitleKeywords) else {
+        let normalizedKeyword = NovelKeywordBlockMatcher.normalizedKeyword(keyword)
+        guard !normalizedKeyword.isEmpty, !NovelKeywordBlockMatcher.containsKeyword(normalizedKeyword, in: blockedNovelTitleKeywords) else {
             return
         }
 
@@ -628,7 +630,7 @@ final class UserSettingStore {
     }
 
     func removeBlockedNovelTitleKeyword(_ keyword: String) throws {
-        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        let normalizedKeyword = NovelKeywordBlockMatcher.normalizedKeyword(keyword)
         blockedNovelTitleKeywords.removeAll {
             $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
         }
@@ -637,8 +639,8 @@ final class UserSettingStore {
     }
 
     func addBlockedNovelSeriesKeyword(_ keyword: String) throws {
-        let normalizedKeyword = normalizedBlockedKeyword(keyword)
-        guard !normalizedKeyword.isEmpty, !containsBlockedKeyword(normalizedKeyword, in: blockedNovelSeriesKeywords) else {
+        let normalizedKeyword = NovelKeywordBlockMatcher.normalizedKeyword(keyword)
+        guard !normalizedKeyword.isEmpty, !NovelKeywordBlockMatcher.containsKeyword(normalizedKeyword, in: blockedNovelSeriesKeywords) else {
             return
         }
 
@@ -648,7 +650,7 @@ final class UserSettingStore {
     }
 
     func removeBlockedNovelSeriesKeyword(_ keyword: String) throws {
-        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        let normalizedKeyword = NovelKeywordBlockMatcher.normalizedKeyword(keyword)
         blockedNovelSeriesKeywords.removeAll {
             $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
         }
@@ -657,8 +659,8 @@ final class UserSettingStore {
     }
 
     func addBlockedNovelCaptionKeyword(_ keyword: String) throws {
-        let normalizedKeyword = normalizedBlockedKeyword(keyword)
-        guard !normalizedKeyword.isEmpty, !containsBlockedKeyword(normalizedKeyword, in: blockedNovelCaptionKeywords) else {
+        let normalizedKeyword = NovelKeywordBlockMatcher.normalizedKeyword(keyword)
+        guard !normalizedKeyword.isEmpty, !NovelKeywordBlockMatcher.containsKeyword(normalizedKeyword, in: blockedNovelCaptionKeywords) else {
             return
         }
 
@@ -668,7 +670,7 @@ final class UserSettingStore {
     }
 
     func removeBlockedNovelCaptionKeyword(_ keyword: String) throws {
-        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        let normalizedKeyword = NovelKeywordBlockMatcher.normalizedKeyword(keyword)
         blockedNovelCaptionKeywords.removeAll {
             $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
         }
@@ -926,7 +928,7 @@ final class UserSettingStore {
 
         if !blockedNovelTitleKeywords.isEmpty || !blockedNovelSeriesKeywords.isEmpty || !blockedNovelCaptionKeywords.isEmpty {
             result = result.filter { novel in
-                !isNovelBlockedByKeywords(
+                !NovelKeywordBlockMatcher.isNovelBlocked(
                     title: novel.title,
                     seriesTitle: novel.series?.title ?? "",
                     caption: TextCleaner.cleanDescription(novel.caption),
@@ -1037,7 +1039,7 @@ final class UserSettingStore {
                 }
 
                 if !blockedNovelTitleKeywordsList.isEmpty || !blockedNovelSeriesKeywordsList.isEmpty || !blockedNovelCaptionKeywordsList.isEmpty {
-                    if isNovelBlockedByKeywords(
+                    if NovelKeywordBlockMatcher.isNovelBlocked(
                         title: title,
                         seriesTitle: seriesTitle,
                         caption: caption,

--- a/Pixiv-SwiftUI/Core/State/Stores/UserSettingStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/UserSettingStore.swift
@@ -5,11 +5,11 @@ import Observation
 let spoilerTags: Set<String> = ["ネタバレ", "spoiler", "ネタバレ注意"]
 
 private enum NovelKeywordBlockMatcher {
-    static func normalizedKeyword(_ keyword: String) -> String {
+    nonisolated static func normalizedKeyword(_ keyword: String) -> String {
         keyword.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    static func containsKeyword(_ keyword: String, in keywords: [String]) -> Bool {
+    nonisolated static func containsKeyword(_ keyword: String, in keywords: [String]) -> Bool {
         let normalizedKeyword = normalizedKeyword(keyword)
         guard !normalizedKeyword.isEmpty else {
             return false
@@ -20,7 +20,7 @@ private enum NovelKeywordBlockMatcher {
         }
     }
 
-    static func matchesKeyword(in text: String, keywords: [String]) -> Bool {
+    nonisolated static func matchesKeyword(in text: String, keywords: [String]) -> Bool {
         let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedText.isEmpty else {
             return false
@@ -36,7 +36,7 @@ private enum NovelKeywordBlockMatcher {
         }
     }
 
-    static func isNovelBlocked(
+    nonisolated static func isNovelBlocked(
         title: String,
         seriesTitle: String,
         caption: String,

--- a/Pixiv-SwiftUI/Core/State/Stores/UserSettingStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/UserSettingStore.swift
@@ -4,6 +4,50 @@ import Observation
 
 let spoilerTags: Set<String> = ["ネタバレ", "spoiler", "ネタバレ注意"]
 
+private func normalizedBlockedKeyword(_ keyword: String) -> String {
+    keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+private func containsBlockedKeyword(_ keyword: String, in keywords: [String]) -> Bool {
+    let normalizedKeyword = normalizedBlockedKeyword(keyword)
+    guard !normalizedKeyword.isEmpty else {
+        return false
+    }
+
+    return keywords.contains {
+        $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+    }
+}
+
+private func matchesBlockedKeyword(in text: String, keywords: [String]) -> Bool {
+    let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalizedText.isEmpty else {
+        return false
+    }
+
+    return keywords.contains { keyword in
+        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        guard !normalizedKeyword.isEmpty else {
+            return false
+        }
+
+        return normalizedText.range(of: normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) != nil
+    }
+}
+
+private func isNovelBlockedByKeywords(
+    title: String,
+    seriesTitle: String,
+    caption: String,
+    titleKeywords: [String],
+    seriesKeywords: [String],
+    captionKeywords: [String]
+) -> Bool {
+    matchesBlockedKeyword(in: title, keywords: titleKeywords)
+        || matchesBlockedKeyword(in: seriesTitle, keywords: seriesKeywords)
+        || matchesBlockedKeyword(in: caption, keywords: captionKeywords)
+}
+
 /// 用户设置管理
 @MainActor
 @Observable
@@ -19,6 +63,9 @@ final class UserSettingStore {
     var blockedUsers: [String] = []
     var blockedIllusts: [Int] = []
     var blockedNovels: [Int] = []
+    var blockedNovelTitleKeywords: [String] = []
+    var blockedNovelSeriesKeywords: [String] = []
+    var blockedNovelCaptionKeywords: [String] = []
 
     var blockedTagInfos: [BlockedTagInfo] = []
     var blockedUserInfos: [BlockedUserInfo] = []
@@ -100,6 +147,9 @@ final class UserSettingStore {
         self.blockedUsers = setting.blockedUsers
         self.blockedIllusts = setting.blockedIllusts
         self.blockedNovels = setting.blockedNovels
+        self.blockedNovelTitleKeywords = setting.blockedNovelTitleKeywords
+        self.blockedNovelSeriesKeywords = setting.blockedNovelSeriesKeywords
+        self.blockedNovelCaptionKeywords = setting.blockedNovelCaptionKeywords
         self.blockedTagInfos = setting.blockedTagInfos
         self.blockedUserInfos = setting.blockedUserInfos
         self.blockedIllustInfos = setting.blockedIllustInfos
@@ -566,6 +616,66 @@ final class UserSettingStore {
         try saveSetting()
     }
 
+    func addBlockedNovelTitleKeyword(_ keyword: String) throws {
+        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        guard !normalizedKeyword.isEmpty, !containsBlockedKeyword(normalizedKeyword, in: blockedNovelTitleKeywords) else {
+            return
+        }
+
+        blockedNovelTitleKeywords.append(normalizedKeyword)
+        userSetting.blockedNovelTitleKeywords = blockedNovelTitleKeywords
+        try saveSetting()
+    }
+
+    func removeBlockedNovelTitleKeyword(_ keyword: String) throws {
+        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        blockedNovelTitleKeywords.removeAll {
+            $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }
+        userSetting.blockedNovelTitleKeywords = blockedNovelTitleKeywords
+        try saveSetting()
+    }
+
+    func addBlockedNovelSeriesKeyword(_ keyword: String) throws {
+        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        guard !normalizedKeyword.isEmpty, !containsBlockedKeyword(normalizedKeyword, in: blockedNovelSeriesKeywords) else {
+            return
+        }
+
+        blockedNovelSeriesKeywords.append(normalizedKeyword)
+        userSetting.blockedNovelSeriesKeywords = blockedNovelSeriesKeywords
+        try saveSetting()
+    }
+
+    func removeBlockedNovelSeriesKeyword(_ keyword: String) throws {
+        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        blockedNovelSeriesKeywords.removeAll {
+            $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }
+        userSetting.blockedNovelSeriesKeywords = blockedNovelSeriesKeywords
+        try saveSetting()
+    }
+
+    func addBlockedNovelCaptionKeyword(_ keyword: String) throws {
+        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        guard !normalizedKeyword.isEmpty, !containsBlockedKeyword(normalizedKeyword, in: blockedNovelCaptionKeywords) else {
+            return
+        }
+
+        blockedNovelCaptionKeywords.append(normalizedKeyword)
+        userSetting.blockedNovelCaptionKeywords = blockedNovelCaptionKeywords
+        try saveSetting()
+    }
+
+    func removeBlockedNovelCaptionKeyword(_ keyword: String) throws {
+        let normalizedKeyword = normalizedBlockedKeyword(keyword)
+        blockedNovelCaptionKeywords.removeAll {
+            $0.compare(normalizedKeyword, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
+        }
+        userSetting.blockedNovelCaptionKeywords = blockedNovelCaptionKeywords
+        try saveSetting()
+    }
+
     /// 过滤插画列表，根据屏蔽设置（同步版本，用于计算属性）
     func filterIllusts(_ illusts: [Illusts]) -> [Illusts] {
         var result = illusts
@@ -814,6 +924,19 @@ final class UserSettingStore {
             }
         }
 
+        if !blockedNovelTitleKeywords.isEmpty || !blockedNovelSeriesKeywords.isEmpty || !blockedNovelCaptionKeywords.isEmpty {
+            result = result.filter { novel in
+                !isNovelBlockedByKeywords(
+                    title: novel.title,
+                    seriesTitle: novel.series?.title ?? "",
+                    caption: TextCleaner.cleanDescription(novel.caption),
+                    titleKeywords: blockedNovelTitleKeywords,
+                    seriesKeywords: blockedNovelSeriesKeywords,
+                    captionKeywords: blockedNovelCaptionKeywords
+                )
+            }
+        }
+
         return result
     }
 
@@ -827,16 +950,30 @@ final class UserSettingStore {
         let tagsSet = blockedTagsSet
         let blockedUsersList = blockedUsers
         let blockedNovelsList = blockedNovels
+        let blockedNovelTitleKeywordsList = blockedNovelTitleKeywords
+        let blockedNovelSeriesKeywordsList = blockedNovelSeriesKeywords
+        let blockedNovelCaptionKeywordsList = blockedNovelCaptionKeywords
         let spoilerTagsSet = spoilerTags
 
-        let novelData = novels.map { ($0.id, $0.xRestrict, $0.novelAIType, $0.user.id.stringValue, $0.tags.map { $0.name }) }
+        let novelData = novels.map {
+            (
+                $0.id,
+                $0.xRestrict,
+                $0.novelAIType,
+                $0.user.id.stringValue,
+                $0.tags.map { $0.name },
+                $0.title,
+                $0.series?.title ?? "",
+                TextCleaner.cleanDescription($0.caption)
+            )
+        }
 
         let indicesToKeep = await Task.detached(priority: .userInitiated) {
             var indicesToKeep: [Int] = []
             indicesToKeep.reserveCapacity(novelData.count)
 
             for (index, data) in novelData.enumerated() {
-                let (id, xRestrict, aiType, userId, tags) = data
+                let (id, xRestrict, aiType, userId, tags, title, seriesTitle, caption) = data
 
                 // R18 过滤 (xRestrict == 1)
                 switch r18Mode {
@@ -895,6 +1032,19 @@ final class UserSettingStore {
                 // 屏蔽小说
                 if !blockedNovelsList.isEmpty {
                     if blockedNovelsList.contains(id) {
+                        continue
+                    }
+                }
+
+                if !blockedNovelTitleKeywordsList.isEmpty || !blockedNovelSeriesKeywordsList.isEmpty || !blockedNovelCaptionKeywordsList.isEmpty {
+                    if isNovelBlockedByKeywords(
+                        title: title,
+                        seriesTitle: seriesTitle,
+                        caption: caption,
+                        titleKeywords: blockedNovelTitleKeywordsList,
+                        seriesKeywords: blockedNovelSeriesKeywordsList,
+                        captionKeywords: blockedNovelCaptionKeywordsList
+                    ) {
                         continue
                     }
                 }

--- a/Pixiv-SwiftUI/Features/Novel/Components/NovelRankingPreview.swift
+++ b/Pixiv-SwiftUI/Features/Novel/Components/NovelRankingPreview.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
 struct NovelRankingPreview: View {
+    @Environment(UserSettingStore.self) private var userSettingStore
     var store: NovelStore
 
     private var novels: [Novel] {
-        store.dailyRankingNovels
+        userSettingStore.filterNovels(store.dailyRankingNovels)
     }
 
     var body: some View {

--- a/Pixiv-SwiftUI/Features/Novel/NovelRankingPage.swift
+++ b/Pixiv-SwiftUI/Features/Novel/NovelRankingPage.swift
@@ -45,11 +45,16 @@ struct NovelRankingPage: View {
 }
 
 struct NovelRankingList: View {
+    @Environment(UserSettingStore.self) private var userSettingStore
     var store: NovelStore
     let mode: NovelRankingMode
 
-    private var novels: [Novel] {
+    private var allNovels: [Novel] {
         store.novels(for: mode)
+    }
+
+    private var novels: [Novel] {
+        userSettingStore.filterNovels(allNovels)
     }
 
     private var nextUrl: String? {
@@ -71,20 +76,33 @@ struct NovelRankingList: View {
 
     var body: some View {
         LazyVStack(spacing: 0) {
-            if store.isLoadingRanking && novels.isEmpty {
+            if store.isLoadingRanking && allNovels.isEmpty {
                 LazyVStack(spacing: 0) {
                     ForEach(0..<5, id: \.self) { _ in
                         SkeletonNovelListCard()
                     }
                 }
             } else if novels.isEmpty {
-                HStack {
-                    Spacer()
-                    Text(String(localized: "暂无排行数据"))
-                        .foregroundColor(.secondary)
-                    Spacer()
+                if hasMoreData {
+                    ProgressView()
+                        #if os(macOS)
+                        .controlSize(.small)
+                        #endif
+                        .padding()
+                        .onAppear {
+                            Task {
+                                await store.loadMoreRanking(mode: mode)
+                            }
+                        }
+                } else {
+                    HStack {
+                        Spacer()
+                        Text(String(localized: "暂无排行数据"))
+                            .foregroundColor(.secondary)
+                        Spacer()
+                    }
+                    .frame(height: 200)
                 }
-                .frame(height: 200)
             } else {
                 ForEach(novels) { novel in
                     NavigationLink(value: novel) {

--- a/Pixiv-SwiftUI/Features/Novel/NovelSeriesView.swift
+++ b/Pixiv-SwiftUI/Features/Novel/NovelSeriesView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct NovelSeriesView: View {
     @Environment(ThemeManager.self) var themeManager
+    @Environment(UserSettingStore.self) private var userSettingStore
     let seriesId: Int
     @State private var store: NovelSeriesStore
     @State private var showExportToast = false
@@ -17,6 +18,10 @@ struct NovelSeriesView: View {
     init(seriesId: Int) {
         self.seriesId = seriesId
         self._store = State(initialValue: NovelSeriesStore(seriesId: seriesId))
+    }
+
+    private var filteredNovels: [Novel] {
+        userSettingStore.filterNovels(store.novels)
     }
 
     var body: some View {
@@ -153,7 +158,7 @@ struct NovelSeriesView: View {
 
             Divider()
 
-            if !store.novels.isEmpty {
+            if !filteredNovels.isEmpty || store.nextUrl != nil || store.isLoadingMore {
                 VStack(alignment: .leading, spacing: 12) {
                     Text("小说列表")
                         .font(.headline)
@@ -196,7 +201,7 @@ struct NovelSeriesView: View {
             }
             .foregroundColor(.secondary)
 
-            if let latestNovel = store.novels.first {
+            if let latestNovel = filteredNovels.first {
                 NavigationLink(value: latestNovel) {
                     Label("查看最新章节", systemImage: "arrow.right.circle.fill")
                         .font(.subheadline)
@@ -216,7 +221,7 @@ struct NovelSeriesView: View {
 
     private var novelList: some View {
         VStack(spacing: 12) {
-            ForEach(Array(store.novels.enumerated()), id: \.element.id) { index, novel in
+            ForEach(Array(filteredNovels.enumerated()), id: \.element.id) { index, novel in
                 NavigationLink(value: novel) {
                     NovelSeriesCard(novel: novel, index: index)
                 }
@@ -224,11 +229,11 @@ struct NovelSeriesView: View {
                 .buttonStyle(.plain)
                 #endif
 
-                if index < store.novels.count - 1 {
+                if index < filteredNovels.count - 1 {
                     Divider()
                 }
 
-                if index == store.novels.count - 1 && store.nextUrl != nil && !store.isLoadingMore {
+                if index == filteredNovels.count - 1 && store.nextUrl != nil && !store.isLoadingMore {
                     Color.clear
                         .frame(height: 1)
                         .onAppear {
@@ -239,7 +244,18 @@ struct NovelSeriesView: View {
                 }
             }
 
-            if store.isLoadingMore {
+            if filteredNovels.isEmpty && store.nextUrl != nil && !store.isLoadingMore {
+                ProgressView()
+                    #if os(macOS)
+                    .controlSize(.small)
+                    #endif
+                    .padding()
+                    .onAppear {
+                        Task {
+                            await store.loadMore()
+                        }
+                    }
+            } else if store.isLoadingMore {
                 HStack {
                     ProgressView()
                         #if os(macOS)
@@ -251,7 +267,7 @@ struct NovelSeriesView: View {
                 }
                 .frame(maxWidth: .infinity)
                 .padding()
-            } else if store.nextUrl == nil && !store.novels.isEmpty {
+            } else if store.nextUrl == nil && !filteredNovels.isEmpty {
                 Text(String(localized: "已经到底了"))
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/Pixiv-SwiftUI/Features/Settings/BlockSettingView.swift
+++ b/Pixiv-SwiftUI/Features/Settings/BlockSettingView.swift
@@ -5,12 +5,18 @@ struct BlockSettingView: View {
     @State private var newTag = ""
     @State private var newUserId = ""
     @State private var newIllustId = ""
+    @State private var newNovelTitleKeyword = ""
+    @State private var newNovelSeriesKeyword = ""
+    @State private var newNovelCaptionKeyword = ""
 
     var body: some View {
         Form {
             tagsSection
             usersSection
             illustsSection
+            novelTitleKeywordsSection
+            novelSeriesKeywordsSection
+            novelCaptionKeywordsSection
         }
         .formStyle(.grouped)
     }
@@ -196,6 +202,103 @@ struct BlockSettingView: View {
             return userSettingStore.blockedIllustInfos
         }
         return userSettingStore.blockedIllusts.map { BlockedIllustInfo(illustId: $0, title: nil, authorId: nil, authorName: nil, thumbnailUrl: nil) }
+    }
+
+    private var novelTitleKeywordsSection: some View {
+        keywordSection(
+            title: "小说标题拉黑关键词",
+            emptyText: "暂无小说标题拉黑关键词",
+            placeholder: "添加小说标题关键词",
+            keywords: userSettingStore.blockedNovelTitleKeywords,
+            text: $newNovelTitleKeyword,
+            addAction: { keyword in
+                try? userSettingStore.addBlockedNovelTitleKeyword(keyword)
+            },
+            removeAction: { keyword in
+                try? userSettingStore.removeBlockedNovelTitleKeyword(keyword)
+            }
+        )
+    }
+
+    private var novelSeriesKeywordsSection: some View {
+        keywordSection(
+            title: "小说系列拉黑关键词",
+            emptyText: "暂无小说系列拉黑关键词",
+            placeholder: "添加小说系列关键词",
+            keywords: userSettingStore.blockedNovelSeriesKeywords,
+            text: $newNovelSeriesKeyword,
+            addAction: { keyword in
+                try? userSettingStore.addBlockedNovelSeriesKeyword(keyword)
+            },
+            removeAction: { keyword in
+                try? userSettingStore.removeBlockedNovelSeriesKeyword(keyword)
+            }
+        )
+    }
+
+    private var novelCaptionKeywordsSection: some View {
+        keywordSection(
+            title: "小说简介拉黑关键词",
+            emptyText: "暂无小说简介拉黑关键词",
+            placeholder: "添加小说简介关键词",
+            keywords: userSettingStore.blockedNovelCaptionKeywords,
+            text: $newNovelCaptionKeyword,
+            addAction: { keyword in
+                try? userSettingStore.addBlockedNovelCaptionKeyword(keyword)
+            },
+            removeAction: { keyword in
+                try? userSettingStore.removeBlockedNovelCaptionKeyword(keyword)
+            }
+        )
+    }
+
+    private func keywordSection(
+        title: String,
+        emptyText: String,
+        placeholder: String,
+        keywords: [String],
+        text: Binding<String>,
+        addAction: @escaping (String) -> Void,
+        removeAction: @escaping (String) -> Void
+    ) -> some View {
+        Section(title) {
+            if keywords.isEmpty {
+                Text(emptyText)
+                    .foregroundColor(.secondary)
+                    .font(.subheadline)
+            } else {
+                ForEach(keywords, id: \.self) { keyword in
+                    HStack(spacing: 12) {
+                        Text(keyword)
+                            .font(.body)
+                            .lineLimit(2)
+
+                        Spacer()
+
+                        Button(action: {
+                            triggerHaptic()
+                            removeAction(keyword)
+                        }) {
+                            Image(systemName: "minus.circle.fill")
+                                .foregroundColor(.red)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+
+            HStack {
+                TextField(placeholder, text: text)
+                Button("添加") {
+                    let keyword = text.wrappedValue
+                    if !keyword.isEmpty {
+                        addAction(keyword)
+                        text.wrappedValue = ""
+                    }
+                }
+                .disabled(text.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
     }
 
     private func triggerHaptic() {

--- a/Pixiv-SwiftUI/Features/Settings/BrowseHistoryView.swift
+++ b/Pixiv-SwiftUI/Features/Settings/BrowseHistoryView.swift
@@ -32,6 +32,10 @@ struct BrowseHistoryView: View {
         #endif
     }
 
+    private var filteredNovels: [Novel] {
+        userSettingStore.filterNovels(novels)
+    }
+
     var body: some View {
         contentView
             .navigationTitle("历史")
@@ -139,9 +143,9 @@ struct BrowseHistoryView: View {
 
     @ViewBuilder
     private var novelListContent: some View {
-        if isLoading && novels.isEmpty {
+        if isLoading && filteredNovels.isEmpty {
             novelLoadingContent
-        } else if novels.isEmpty {
+        } else if filteredNovels.isEmpty && loadedCount >= allHistoryIds.count {
             emptyContent(type: "小说")
         } else {
             novelList
@@ -215,13 +219,13 @@ struct BrowseHistoryView: View {
 
     private var novelList: some View {
         Group {
-            ForEach(novels, id: \.id) { novel in
+            ForEach(filteredNovels, id: \.id) { novel in
                 NavigationLink(value: novel) {
                     NovelListCard(novel: novel)
                 }
                 .buttonStyle(.plain)
 
-                if novel.id != novels.last?.id {
+                if novel.id != filteredNovels.last?.id {
                     Divider()
                         .padding(.leading, 12)
                 }
@@ -236,7 +240,7 @@ struct BrowseHistoryView: View {
                     .onAppear {
                         Task { await loadMore() }
                     }
-            } else if !novels.isEmpty {
+            } else if !filteredNovels.isEmpty {
                 Text(String(localized: "已经到底了"))
                     .font(.caption)
                     .foregroundColor(.secondary)

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelCard.swift
@@ -122,6 +122,20 @@ struct NovelCard: View {
                     Label("屏蔽此作者", systemImage: "person.slash")
                 }
 
+                Button(role: .destructive) {
+                    try? UserSettingStore.shared.addBlockedNovelTitleKeyword(novel.title)
+                } label: {
+                    Label("按标题拉黑", systemImage: "textformat")
+                }
+
+                if let seriesTitle = novel.series?.title, !seriesTitle.isEmpty {
+                    Button(role: .destructive) {
+                        try? UserSettingStore.shared.addBlockedNovelSeriesKeyword(seriesTitle)
+                    } label: {
+                        Label("按系列拉黑", systemImage: "books.vertical")
+                    }
+                }
+
                 Menu {
                     ForEach(novel.tags, id: \.name) { tag in
                         Button {

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelListCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelListCard.swift
@@ -150,6 +150,20 @@ struct NovelListCard: View {
                     Label("屏蔽此作者", systemImage: "person.slash")
                 }
 
+                Button(role: .destructive) {
+                    try? UserSettingStore.shared.addBlockedNovelTitleKeyword(novel.title)
+                } label: {
+                    Label("按标题拉黑", systemImage: "textformat")
+                }
+
+                if let seriesTitle = novel.series?.title, !seriesTitle.isEmpty {
+                    Button(role: .destructive) {
+                        try? UserSettingStore.shared.addBlockedNovelSeriesKeyword(seriesTitle)
+                    } label: {
+                        Label("按系列拉黑", systemImage: "books.vertical")
+                    }
+                }
+
                 Menu {
                     ForEach(novel.tags, id: \.name) { tag in
                         Button {

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelSeriesCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelSeriesCard.swift
@@ -127,6 +127,20 @@ struct NovelSeriesCard: View {
                     Label("屏蔽此作者", systemImage: "person.slash")
                 }
 
+                Button(role: .destructive) {
+                    try? UserSettingStore.shared.addBlockedNovelTitleKeyword(novel.title)
+                } label: {
+                    Label("按标题拉黑", systemImage: "textformat")
+                }
+
+                if let seriesTitle = novel.series?.title, !seriesTitle.isEmpty {
+                    Button(role: .destructive) {
+                        try? UserSettingStore.shared.addBlockedNovelSeriesKeyword(seriesTitle)
+                    } label: {
+                        Label("按系列拉黑", systemImage: "books.vertical")
+                    }
+                }
+
                 Menu {
                     ForEach(novel.tags, id: \.name) { tag in
                         Button {


### PR DESCRIPTION
## Why
Pixiv novel search is increasingly polluted by spam posts that reuse many popular tags. Tag-based or author-based blocking is not enough because these accounts and works rotate constantly, while the recurring spam signal is usually embedded in the novel title, series title, or caption.

The app already had mute rules for tags, authors, and novel IDs, but it could still display already-fetched spam novels if they matched the current search or list entrypoint. This makes novel search and discovery much harder to use.

## What changed
- added three local novel keyword block lists in user settings:
  - title keywords
  - series keywords
  - caption keywords
- applied those rules inside the central novel filtering path so matching novels are hidden locally even after they have already been fetched
- normalized matching to case-insensitive substring checks
- cleaned caption HTML before matching so rules work on visible text instead of raw markup
- updated the remaining novel list surfaces to consistently use the shared novel filter logic
- added settings UI for managing the three keyword block lists
- included the new rules in sync/export/import flows so the block lists travel with user data
- added targeted Swift 6 concurrency fixes required by the new background filtering path

## Result
- spam novels that hide behind popular tags can now be filtered by the more stable signals they expose in title, series, or caption
- the filtering is local, so it also works for already-cached or already-fetched content
- novel search, ranking, history, and series pages all behave consistently once a keyword rule is added

## Testing
- passed GitHub Actions CI build for the branch after the Swift 6 concurrency fixes were applied
- manually verified the new block rules on the affected novel surfaces and confirmed that matching novels no longer appear once the corresponding title, series, or caption keyword is added
