### PR TITLE
fix: keep search keyboard closed after back navigation

### DIFF
--- a/Pixiv-SwiftUI/Features/Search/SearchView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchView.swift
@@ -181,7 +181,7 @@ struct SearchView: View {
         NavigationStack(path: $path) {
             VStack(spacing: 0) {
                 #if os(iOS)
-                if store.searchText.isEmpty {
+                if store.searchText.isEmpty || !isSearchPresented {
                     searchHistoryAndTrends
                 } else {
                     suggestionList
@@ -278,9 +278,6 @@ struct SearchView: View {
             }
             .onAppear {
                 store.loadSearchHistory()
-                if !store.searchText.isEmpty {
-                    isSearchPresented = true
-                }
             }
             .onSubmit(of: .search) {
                 guard accountStore.isLoggedIn else { return }


### PR DESCRIPTION
## Why
When leaving the search result page on iPhone, the app navigated back to the suggestion page and then reopened the keyboard a moment later. This happened because the previous search text was still present, and the search page treated any non-empty text as a signal to reopen the active search UI.

That behavior makes back navigation feel unstable and interrupts normal browsing flow.

## What changed
- stopped automatically reopening the active search presentation on `SearchView` appearance just because stored search text still exists
- made the suggestion list depend on the actual search presentation state instead of only checking whether the last query string is non-empty

## Result
- returning from a search result page no longer reopens the keyboard on its own
- the search page returns to a stable resting state
- users can still tap the search field again whenever they want to continue editing the query

## Testing
- passed GitHub Actions CI build for the branch
- manually verified back navigation from the search result page on iPhone and confirmed that the keyboard stays closed until the user explicitly taps the search field again
