### PR TITLE
feat: streamline search result filters

### DIFF
--- a/Pixiv-SwiftUI/Features/Search/SearchResultView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchResultView.swift
@@ -1,5 +1,24 @@
 import SwiftUI
 
+private struct SearchFilterState: Equatable {
+    var bookmarkFilter: BookmarkFilterOption = .none
+    var searchTarget: SearchTargetOption = .partialMatchForTags
+    var showsAIGeneratedWorks = true
+    var startDate: Date?
+    var endDate: Date?
+
+    var hasDateRange: Bool {
+        startDate != nil || endDate != nil
+    }
+
+    var hasActiveFilters: Bool {
+        bookmarkFilter != .none
+            || searchTarget != .partialMatchForTags
+            || !showsAIGeneratedWorks
+            || hasDateRange
+    }
+}
+
 struct SearchResultView: View {
     let word: String
     let preloadToken: UUID?
@@ -7,11 +26,7 @@ struct SearchResultView: View {
     @State private var selectedTab = 0
     @State private var sortOption: SearchSortOption = SearchSortOption(rawValue: UserSettingStore.shared.userSetting.defaultSearchSort) ?? .dateDesc
     @State private var novelSortOption: SearchSortOption = SearchSortOption(rawValue: UserSettingStore.shared.userSetting.defaultSearchSort) ?? .dateDesc
-    @State private var bookmarkFilter: BookmarkFilterOption = .none
-    @State private var searchTarget: SearchTargetOption = .partialMatchForTags
-    @State private var showsAIGeneratedWorks: Bool = true
-    @State private var startDate: Date?
-    @State private var endDate: Date?
+    @State private var filterState = SearchFilterState()
     @Environment(UserSettingStore.self) var settingStore
     @Environment(AccountStore.self) var accountStore
     @Environment(ThemeManager.self) var themeManager
@@ -59,11 +74,11 @@ struct SearchResultView: View {
             prefetchNovelPreferLocalPopularSort: novelSortOption == .popularDesc && accountStore.currentAccount?.isPremium != 1,
             allowsPseudoPopularPreload: accountStore.currentAccount?.isPremium != 1,
             preloadToken: preloadToken,
-            showsAIGenerated: showsAIGeneratedWorks,
-            bookmarkFilter: bookmarkFilter,
-            searchTarget: searchTarget,
-            startDate: startDate,
-            endDate: endDate
+            showsAIGenerated: filterState.showsAIGeneratedWorks,
+            bookmarkFilter: filterState.bookmarkFilter,
+            searchTarget: filterState.searchTarget,
+            startDate: filterState.startDate,
+            endDate: filterState.endDate
         )
     }
 
@@ -73,11 +88,11 @@ struct SearchResultView: View {
             sort: novelSortOption.rawValue,
             preferLocalPopularSort: novelSortOption == .popularDesc && accountStore.currentAccount?.isPremium != 1,
             allowsPseudoPopularPreload: accountStore.currentAccount?.isPremium != 1,
-            showsAIGenerated: showsAIGeneratedWorks,
-            bookmarkFilter: bookmarkFilter,
-            searchTarget: searchTarget,
-            startDate: startDate,
-            endDate: endDate
+            showsAIGenerated: filterState.showsAIGeneratedWorks,
+            bookmarkFilter: filterState.bookmarkFilter,
+            searchTarget: filterState.searchTarget,
+            startDate: filterState.startDate,
+            endDate: filterState.endDate
         )
     }
 
@@ -94,11 +109,11 @@ struct SearchResultView: View {
             word: word,
             sort: sortOption.rawValue,
             preferLocalPopularSort: sortOption == .popularDesc && accountStore.currentAccount?.isPremium != 1,
-            showsAIGenerated: showsAIGeneratedWorks,
-            bookmarkFilter: bookmarkFilter,
-            searchTarget: searchTarget,
-            startDate: startDate,
-            endDate: endDate
+            showsAIGenerated: filterState.showsAIGeneratedWorks,
+            bookmarkFilter: filterState.bookmarkFilter,
+            searchTarget: filterState.searchTarget,
+            startDate: filterState.startDate,
+            endDate: filterState.endDate
         )
     }
 
@@ -107,11 +122,11 @@ struct SearchResultView: View {
             word: word,
             sort: novelSortOption.rawValue,
             preferLocalPopularSort: novelSortOption == .popularDesc && accountStore.currentAccount?.isPremium != 1,
-            showsAIGenerated: showsAIGeneratedWorks,
-            bookmarkFilter: bookmarkFilter,
-            searchTarget: searchTarget,
-            startDate: startDate,
-            endDate: endDate
+            showsAIGenerated: filterState.showsAIGeneratedWorks,
+            bookmarkFilter: filterState.bookmarkFilter,
+            searchTarget: filterState.searchTarget,
+            startDate: filterState.startDate,
+            endDate: filterState.endDate
         )
     }
 
@@ -170,8 +185,24 @@ struct SearchResultView: View {
             .padding()
             .frame(minHeight: 300)
         } else if filteredIllusts.isEmpty && !store.isLoading {
+            if store.illustHasMore {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .onAppear {
+                            Task {
+                                await loadMoreIllustResults()
+                            }
+                        }
+
+                    Text("正在加载更多结果")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .frame(minHeight: 300)
+            } else {
             ContentUnavailableView("没有找到插画", systemImage: "magnifyingglass", description: Text("尝试搜索其他标签"))
                 .frame(minHeight: 300)
+            }
         } else {
             VStack(spacing: 12) {
                 WaterfallGrid(data: filteredIllusts, columnCount: columnCount, width: waterfallWidth, aspectRatio: { $0.safeAspectRatio }) { illust, columnWidth in
@@ -211,26 +242,42 @@ struct SearchResultView: View {
     @ViewBuilder
     private var novelTabContent: some View {
         if filteredNovels.isEmpty && !store.novelResults.isEmpty && !store.isLoading {
-            VStack(spacing: 20) {
-                Spacer()
+            if store.novelHasMore {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .onAppear {
+                            Task {
+                                await loadMoreNovelResults()
+                            }
+                        }
 
-                Image(systemName: "book.closed")
-                    .font(.system(size: 60))
-                    .foregroundColor(.secondary)
+                    Text("正在加载更多结果")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .frame(minHeight: 300)
+            } else {
+                VStack(spacing: 20) {
+                    Spacer()
 
-                Text("没有找到小说")
-                    .font(.title2)
-                    .foregroundColor(.primary)
+                    Image(systemName: "book.closed")
+                        .font(.system(size: 60))
+                        .foregroundColor(.secondary)
 
-                Text("尝试搜索其他标签")
-                    .font(.body)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
+                    Text("没有找到小说")
+                        .font(.title2)
+                        .foregroundColor(.primary)
 
-                Spacer()
+                    Text("尝试搜索其他标签")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal)
+
+                    Spacer()
+                }
+                .frame(minHeight: 300)
             }
-            .frame(minHeight: 300)
         } else {
             LazyVStack(spacing: 12) {
                 ForEach(filteredNovels) { novel in
@@ -319,32 +366,22 @@ struct SearchResultView: View {
     @ToolbarContentBuilder
     private var searchToolbar: some ToolbarContent {
         if selectedTab == 0 {
-            ToolbarItem {
-                HStack(spacing: 0) {
-                    BookmarkFilterButton(selectedFilter: $bookmarkFilter)
-                    SearchTargetFilterButton(selectedTarget: $searchTarget)
-                    SearchAIFilterButton(showsAIGeneratedWorks: $showsAIGeneratedWorks)
-                    SearchDateRangeFilterButton(startDate: $startDate, endDate: $endDate)
-                    SearchSortButton(
-                        sortOption: $sortOption,
-                        isPremium: accountStore.currentAccount?.isPremium == 1,
-                        contentType: .illust
-                    )
-                }
+            ToolbarItemGroup(placement: .primaryAction) {
+                SearchFiltersButton(filterState: $filterState)
+                SearchSortButton(
+                    sortOption: $sortOption,
+                    isPremium: accountStore.currentAccount?.isPremium == 1,
+                    contentType: .illust
+                )
             }
         } else if selectedTab == 1 {
-            ToolbarItem {
-                HStack(spacing: 0) {
-                    BookmarkFilterButton(selectedFilter: $bookmarkFilter)
-                    SearchTargetFilterButton(selectedTarget: $searchTarget)
-                    SearchAIFilterButton(showsAIGeneratedWorks: $showsAIGeneratedWorks)
-                    SearchDateRangeFilterButton(startDate: $startDate, endDate: $endDate)
-                    SearchSortButton(
-                        sortOption: $novelSortOption,
-                        isPremium: accountStore.currentAccount?.isPremium == 1,
-                        contentType: .novel
-                    )
-                }
+            ToolbarItemGroup(placement: .primaryAction) {
+                SearchFiltersButton(filterState: $filterState)
+                SearchSortButton(
+                    sortOption: $novelSortOption,
+                    isPremium: accountStore.currentAccount?.isPremium == 1,
+                    contentType: .novel
+                )
             }
         }
     }
@@ -389,27 +426,7 @@ struct SearchResultView: View {
                     await performNovelSearch()
                 }
             }
-            .onChange(of: bookmarkFilter) { _, _ in
-                Task {
-                    await performCurrentTabSearch()
-                }
-            }
-            .onChange(of: searchTarget) { _, _ in
-                Task {
-                    await performCurrentTabSearch()
-                }
-            }
-            .onChange(of: showsAIGeneratedWorks) { _, _ in
-                Task {
-                    await performCurrentTabSearch()
-                }
-            }
-            .onChange(of: startDate) { _, _ in
-                Task {
-                    await performCurrentTabSearch()
-                }
-            }
-            .onChange(of: endDate) { _, _ in
+            .onChange(of: filterState) { _, _ in
                 Task {
                     await performCurrentTabSearch()
                 }
@@ -467,5 +484,190 @@ private struct SearchAIFilterButton: View {
             Image(systemName: "sparkles")
                 .symbolVariant(showsAIGeneratedWorks ? .none : .fill)
         }
+    }
+}
+
+private struct SearchFiltersButton: View {
+    @Binding var filterState: SearchFilterState
+    @State private var isPresentingSheet = false
+
+    var body: some View {
+        Button {
+            isPresentingSheet = true
+        } label: {
+            Image(systemName: "line.3.horizontal.decrease.circle")
+                .symbolVariant(filterState.hasActiveFilters ? .fill : .none)
+        }
+        #if os(macOS)
+        .popover(isPresented: $isPresentingSheet, arrowEdge: .bottom) {
+            SearchFiltersSheet(filterState: $filterState)
+                .frame(width: 360)
+        }
+        #else
+        .sheet(isPresented: $isPresentingSheet) {
+            SearchFiltersSheet(filterState: $filterState)
+        }
+        #endif
+    }
+}
+
+private struct SearchFiltersSheet: View {
+    @Binding var filterState: SearchFilterState
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draftState: SearchFilterState
+    @State private var isDateRangeEnabled: Bool
+
+    private let minDate: Date
+
+    init(filterState: Binding<SearchFilterState>) {
+        _filterState = filterState
+        let initialState = filterState.wrappedValue
+        _draftState = State(initialValue: initialState)
+        _isDateRangeEnabled = State(initialValue: initialState.hasDateRange)
+        minDate = Calendar.current.date(from: DateComponents(year: 2007, month: 8, day: 1)) ?? .distantPast
+    }
+
+    var body: some View {
+        #if os(macOS)
+        VStack(alignment: .leading, spacing: 16) {
+            Text("筛选")
+                .font(.headline)
+
+            bookmarkFilterSection
+            searchTargetSection
+            aiFilterSection
+            dateRangeSection
+
+            HStack {
+                Button("重置") {
+                    resetFilters()
+                }
+
+                Spacer()
+
+                Button("取消") {
+                    dismiss()
+                }
+
+                Button("应用") {
+                    applyFilters()
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(16)
+        #else
+        NavigationStack {
+            Form {
+                bookmarkFilterSection
+                searchTargetSection
+                aiFilterSection
+                dateRangeSection
+            }
+            .navigationTitle("筛选")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("应用") {
+                        applyFilters()
+                    }
+                }
+
+                ToolbarItem(placement: .bottomBar) {
+                    Button("重置") {
+                        resetFilters()
+                    }
+                }
+            }
+        }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #endif
+        #endif
+    }
+
+    private var bookmarkFilterSection: some View {
+        Section("收藏阈值") {
+            Picker("收藏阈值", selection: $draftState.bookmarkFilter) {
+                ForEach(BookmarkFilterOption.allCases) { option in
+                    Text(option.displayName).tag(option)
+                }
+            }
+        }
+    }
+
+    private var searchTargetSection: some View {
+        Section("搜索范围") {
+            Picker("搜索范围", selection: $draftState.searchTarget) {
+                ForEach(SearchTargetOption.allCases) { option in
+                    Text(option.displayName).tag(option)
+                }
+            }
+        }
+    }
+
+    private var aiFilterSection: some View {
+        Section("内容过滤") {
+            Toggle("显示 AI 生成作品", isOn: $draftState.showsAIGeneratedWorks)
+        }
+    }
+
+    private var dateRangeSection: some View {
+        Section("时间范围") {
+            Toggle("启用时间筛选", isOn: $isDateRangeEnabled)
+
+            if isDateRangeEnabled {
+                DatePicker(
+                    "开始日期",
+                    selection: Binding(
+                        get: { draftState.startDate ?? draftState.endDate ?? Date() },
+                        set: { draftState.startDate = $0 }
+                    ),
+                    in: minDate...Date(),
+                    displayedComponents: .date
+                )
+
+                DatePicker(
+                    "结束日期",
+                    selection: Binding(
+                        get: { draftState.endDate ?? draftState.startDate ?? Date() },
+                        set: { draftState.endDate = $0 }
+                    ),
+                    in: minDate...Date(),
+                    displayedComponents: .date
+                )
+            }
+        }
+    }
+
+    private func resetFilters() {
+        draftState = SearchFilterState()
+        isDateRangeEnabled = false
+    }
+
+    private func applyFilters() {
+        if isDateRangeEnabled {
+            var normalizedStartDate = Calendar.current.startOfDay(for: draftState.startDate ?? Date())
+            var normalizedEndDate = Calendar.current.startOfDay(for: draftState.endDate ?? normalizedStartDate)
+
+            if normalizedStartDate > normalizedEndDate {
+                swap(&normalizedStartDate, &normalizedEndDate)
+            }
+
+            draftState.startDate = normalizedStartDate
+            draftState.endDate = normalizedEndDate
+        } else {
+            draftState.startDate = nil
+            draftState.endDate = nil
+        }
+
+        filterState = draftState
+        dismiss()
     }
 }


### PR DESCRIPTION
## Why
The search result page currently packs several filter controls into a very tight area. On iPhone, that makes the top-right control cluster harder to scan and easier to mis-tap, especially once time filtering is involved.

This part of the search experience needed a cleaner layout so users can understand and adjust filters without fighting the UI.

## What changed
- reorganized the search result filter controls into a less crowded layout on iPhone
- tightened the related state handling in the result view so the updated filter UI stays in sync with the active search conditions
- adjusted the surrounding result-page presentation to better accommodate the revised control arrangement

## Result
- the search result page is easier to read and operate on iPhone
- filter controls no longer feel crammed into the top-right corner
- users can review and adjust active search filters with less visual noise

## Testing
- passed GitHub Actions CI build in the fork while validating the patch series that includes this change
- manually verified the updated search result filter layout and interactions on iPhone
