### PR TITLE
fix: improve search history and query interactions

### DIFF
--- a/Pixiv-SwiftUI/Core/State/Stores/SearchResultStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/SearchResultStore.swift
@@ -1418,7 +1418,10 @@ final class SearchResultStore {
     }
 
     private func normalizeSearchWord(_ word: String) -> String {
-        word.trimmingCharacters(in: .whitespacesAndNewlines)
+        word
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 
     private func effectivePseudoPopularMinimumBookmarkCount(

--- a/Pixiv-SwiftUI/Core/State/Stores/SearchStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/SearchStore.swift
@@ -41,12 +41,10 @@ class SearchStore {
             .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
             .sink { [weak self] text in
                 guard let self = self else { return }
-                let trimmedText = text.trimmingCharacters(in: .whitespaces)
-                if trimmedText.isEmpty {
+                guard let searchWord = self.activeSuggestionToken(in: text) else {
                     self.suggestions = []
                     return
                 }
-                let searchWord = trimmedText.split(separator: " ").last.map(String.init) ?? trimmedText
                 Task {
                     await self.fetchSuggestions(word: searchWord)
                 }
@@ -100,6 +98,26 @@ class SearchStore {
     func removeHistory(_ name: String) {
         searchHistory.removeAll { $0.name == name }
         saveSearchHistory()
+    }
+
+    private func activeSuggestionToken(in text: String) -> String? {
+        guard !text.isEmpty else { return nil }
+        guard let lastScalar = text.unicodeScalars.last, !CharacterSet.whitespacesAndNewlines.contains(lastScalar) else {
+            return nil
+        }
+
+        let tokens = text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+
+        guard var token = tokens.last else { return nil }
+        if token.hasPrefix("-"), token.count > 1 {
+            token.removeFirst()
+        }
+        guard !token.isEmpty, token.uppercased() != "OR" else {
+            return nil
+        }
+        return token
     }
 
     func fetchTrendTags() async {

--- a/Pixiv-SwiftUI/Features/Novel/NovelDetail/NovelDetailView.swift
+++ b/Pixiv-SwiftUI/Features/Novel/NovelDetail/NovelDetailView.swift
@@ -304,6 +304,16 @@ struct NovelDetailView: View {
             Text(String(localized: "删除后将无法恢复，确定要删除这个作品吗？"))
         }
         #if os(iOS)
+        .sheet(isPresented: $showComments) {
+            NovelCommentsPanelView(
+                novel: novelData,
+                isPresented: $showComments,
+                onUserTapped: { userId in
+                    showComments = false
+                    navigateToUserId = userId
+                }
+            )
+        }
         .sheet(isPresented: $showDocumentPicker) {
             if let tempURL = exportTempURL {
                 DocumentPickerView(tempURL: tempURL, filename: exportFilename)

--- a/Pixiv-SwiftUI/Features/Search/Components/SearchSuggestionView.swift
+++ b/Pixiv-SwiftUI/Features/Search/Components/SearchSuggestionView.swift
@@ -9,7 +9,6 @@ struct SearchSuggestionView: View {
     var triggerHaptic: () -> Void
     var copyToClipboard: (String) -> Void
     var addBlockedTag: (String, String?) -> Void
-    var onSearch: ((String) -> Void)? // 可选的立即搜索回调
 
     var body: some View {
         Group {
@@ -60,22 +59,9 @@ struct SearchSuggestionView: View {
             if !store.suggestions.isEmpty {
                 Section("标签建议") {
                     ForEach(store.suggestions) { tag in
-                    Button {
-                        let words = store.searchText.split(separator: " ")
-                        var newText = ""
-                        // 处理��选标签补全
-                        if words.count > 1 {
-                            newText = String(words.dropLast().joined(separator: " ") + " ")
-                        }
-                        newText += tag.tagName + " "
-                        let completedText = newText.trimmingCharacters(in: .whitespaces)
-                        store.searchText = completedText
-
-                        // 如果提供了搜索回调，则立即执行搜索并添加到历史记录
-                        if let onSearch = onSearch {
-                            onSearch(completedText)
-                        }
-                    } label: {
+                        Button {
+                            store.searchText = completedSearchText(with: tag.tagName)
+                        } label: {
                         HStack {
                             Image(systemName: tag.isLocalMatch ? "checkmark.circle" : "magnifyingglass")
                                 .foregroundColor(tag.isLocalMatch ? .accentColor : .secondary)
@@ -132,6 +118,24 @@ struct SearchSuggestionView: View {
             }
             #endif
         }
+    }
+
+    private func completedSearchText(with tagName: String) -> String {
+        let hasTrailingWhitespace = store.searchText.unicodeScalars.last.map {
+            CharacterSet.whitespacesAndNewlines.contains($0)
+        } ?? false
+
+        let tokens = store.searchText
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+
+        var completedTokens = tokens
+        if hasTrailingWhitespace || completedTokens.isEmpty {
+            completedTokens.append(tagName)
+        } else {
+            completedTokens[completedTokens.count - 1] = tagName
+        }
+        return completedTokens.joined(separator: " ") + " "
     }
 
     private var extractedNumber: Int? {

--- a/Pixiv-SwiftUI/Features/Search/SearchView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchView.swift
@@ -242,30 +242,6 @@ struct SearchView: View {
                             Image(systemName: "photo.badge.magnifyingglass")
                         }
                     }
-                    #if os(iOS)
-                    if #available(iOS 26.0, *) {
-                        if !store.searchHistory.isEmpty && store.searchText.isEmpty {
-                            ToolbarSpacer(.fixed)
-                        }
-                    }
-                    #endif
-                }
-                if !store.searchHistory.isEmpty && store.searchText.isEmpty && accountStore.isLoggedIn {
-                    ToolbarItem {
-                        Button(action: {
-                            showClearHistoryConfirmation = true
-                        }) {
-                            Image(systemName: "trash")
-                        }
-                        .confirmationDialog(String(localized: "确定要清除所有搜索历史吗？"), isPresented: $showClearHistoryConfirmation, titleVisibility: .visible) {
-                            Button(String(localized: "清除所有"), role: .destructive) {
-                                triggerHaptic()
-                                store.clearHistory()
-                                isHistoryExpanded = false
-                            }
-                            Button(String(localized: "取消"), role: .cancel) {}
-                        }
-                    }
                 }
                 #if os(iOS)
                 if #available(iOS 26.0, *) {
@@ -426,10 +402,33 @@ struct SearchView: View {
         ScrollView {
             VStack(alignment: .leading) {
                 if !store.searchHistory.isEmpty {
-                    Text("搜索历史")
-                        .font(.headline)
-                        .padding(.horizontal)
-                        .padding(.top)
+                    HStack(spacing: 12) {
+                        Text("搜索历史")
+                            .font(.headline)
+
+                        Spacer()
+
+                        if accountStore.isLoggedIn {
+                            Button(action: {
+                                showClearHistoryConfirmation = true
+                            }) {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "trash")
+                                    Text("清空")
+                                }
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundColor(.secondary)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 6)
+                                .background(Color.secondary.opacity(0.12))
+                                .cornerRadius(12)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.top)
 
                     FlowLayout(spacing: 6) {
                         let historyToDisplay = isHistoryExpanded ? store.searchHistory : Array(store.searchHistory.prefix(10))
@@ -600,6 +599,14 @@ struct SearchView: View {
                     .padding(.horizontal)
                 }
             }
+        }
+        .confirmationDialog(String(localized: "确定要清除所有搜索历史吗？"), isPresented: $showClearHistoryConfirmation, titleVisibility: .visible) {
+            Button(String(localized: "清除所有"), role: .destructive) {
+                triggerHaptic()
+                store.clearHistory()
+                isHistoryExpanded = false
+            }
+            Button(String(localized: "取消"), role: .cancel) {}
         }
     }
 

--- a/Pixiv-SwiftUI/Features/Search/SearchView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchView.swift
@@ -627,8 +627,7 @@ struct SearchView: View {
                 addBlockedTag: { name, translatedName in
                     try? userSettingStore.addBlockedTagWithInfo(name, translatedName: translatedName)
                     showBlockToast = true
-                },
-                onSearch: { performSearch(word: $0) }
+                }
             )
         }
         .listStyle(.plain)

--- a/Pixiv-SwiftUI/Features/Search/SearchView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchView.swift
@@ -154,9 +154,16 @@ struct SearchView: View {
         accountStore.isLoggedIn ? String(localized: "搜索插画、小说和画师") : String(localized: "请先登录以使用搜索")
     }
 
+    private func normalizedSearchQuery(_ text: String) -> String {
+        text
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
     @MainActor
     private func performSearch(word: String, translatedName: String? = nil) {
-        let normalizedWord = word.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedWord = normalizedSearchQuery(word)
         guard !normalizedWord.isEmpty else { return }
 
         isSearchPresented = false
@@ -208,8 +215,7 @@ struct SearchView: View {
                     addBlockedTag: { name, translatedName in
                         try? userSettingStore.addBlockedTagWithInfo(name, translatedName: translatedName)
                         showBlockToast = true
-                    },
-                    onSearch: { performSearch(word: $0) }
+                    }
                 )
             }
             #else
@@ -227,8 +233,7 @@ struct SearchView: View {
                     addBlockedTag: { name, translatedName in
                         try? userSettingStore.addBlockedTagWithInfo(name, translatedName: translatedName)
                         showBlockToast = true
-                    },
-                    onSearch: { performSearch(word: $0) }
+                    }
                 )
             }
             #endif

--- a/Pixiv-SwiftUI/Features/Search/SearchView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchView.swift
@@ -4,6 +4,27 @@ import UniformTypeIdentifiers
 import PhotosUI
 #endif
 
+private struct SearchHistoryQueryChip: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+
+            Text(text)
+                .font(.subheadline)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.secondary.opacity(0.12))
+        .clipShape(Capsule())
+    }
+}
+
 struct SearchView: View {
     @State private var store = SearchStore.shared
     @State private var selectedTag: String = ""
@@ -159,6 +180,10 @@ struct SearchView: View {
             .components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
             .joined(separator: " ")
+    }
+
+    private func isSingleSearchTerm(_ query: String) -> Bool {
+        !query.contains(where: \.isWhitespace)
     }
 
     @MainActor
@@ -443,21 +468,21 @@ struct SearchView: View {
                                     Button(action: {
                                         performSearch(word: tag.name, translatedName: tag.translatedName)
                                     }) {
-                                        TagChip(searchTag: tag)
+                                        SearchHistoryQueryChip(text: tag.name)
                                     }
                                     .buttonStyle(.plain)
                                 } else {
-                                    TagChip(searchTag: tag)
+                                    SearchHistoryQueryChip(text: tag.name)
                                 }
                             }
                             .contextMenu {
                                 Button(action: {
                                     copyToClipboard(tag.name)
                                 }) {
-                                    Label(String(localized: "复制 tag"), systemImage: "doc.on.doc")
+                                    Label(String(localized: "复制搜索内容"), systemImage: "doc.on.doc")
                                 }
 
-                                if accountStore.isLoggedIn {
+                                if accountStore.isLoggedIn && isSingleSearchTerm(tag.name) {
                                     Button(action: {
                                         triggerHaptic()
                                         try? userSettingStore.addBlockedTagWithInfo(tag.name, translatedName: tag.translatedName)

--- a/Pixiv-SwiftUI/Features/Search/SearchView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchView.swift
@@ -455,6 +455,18 @@ struct SearchView: View {
                                 .cornerRadius(12)
                             }
                             .buttonStyle(.plain)
+                            .confirmationDialog(
+                                String(localized: "确定要清除所有搜索历史吗？"),
+                                isPresented: $showClearHistoryConfirmation,
+                                titleVisibility: .visible
+                            ) {
+                                Button(String(localized: "清除所有"), role: .destructive) {
+                                    triggerHaptic()
+                                    store.clearHistory()
+                                    isHistoryExpanded = false
+                                }
+                                Button(String(localized: "取消"), role: .cancel) {}
+                            }
                         }
                     }
                     .padding(.horizontal)
@@ -629,14 +641,6 @@ struct SearchView: View {
                     .padding(.horizontal)
                 }
             }
-        }
-        .confirmationDialog(String(localized: "确定要清除所有搜索历史吗？"), isPresented: $showClearHistoryConfirmation, titleVisibility: .visible) {
-            Button(String(localized: "清除所有"), role: .destructive) {
-                triggerHaptic()
-                store.clearHistory()
-                isHistoryExpanded = false
-            }
-            Button(String(localized: "取消"), role: .cancel) {}
         }
     }
 

--- a/Pixiv-SwiftUI/Features/Settings/BrowseHistoryView.swift
+++ b/Pixiv-SwiftUI/Features/Settings/BrowseHistoryView.swift
@@ -185,7 +185,7 @@ struct BrowseHistoryView: View {
     private func illustGrid(columnCount: Int, waterfallWidth: CGFloat?) -> some View {
         VStack(spacing: 12) {
             WaterfallGrid(data: illusts, columnCount: columnCount, width: waterfallWidth, aspectRatio: { $0.safeAspectRatio }) { illust, columnWidth in
-                NavigationLink(value: IllustIdTarget(id: illust.id)) {
+                NavigationLink(value: illust) {
                     BrowseHistoryCard(illust: illust, columnWidth: columnWidth)
                 }
                 .buttonStyle(.plain)

--- a/Pixiv-SwiftUI/Shared/Components/Profile/ProfilePanelView+iOS.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Profile/ProfilePanelView+iOS.swift
@@ -314,6 +314,9 @@ struct ProfilePanelView: View {
             .navigationDestination(for: Illusts.self) { illust in
                 IllustDetailView(illust: illust)
             }
+            .navigationDestination(for: Novel.self) { novel in
+                NovelDetailView(novel: novel)
+            }
             .navigationDestination(for: User.self) { user in
                 UserDetailView(userId: user.id.stringValue)
             }


### PR DESCRIPTION
## Why
Several search interactions had become unreliable. History items could stop responding, clearing history could behave inconsistently, and the search screen still carried some stale callback logic from the previous suggestion flow.

Multi-tag searches were also awkward to reason about because space-separated input was not handled cleanly in the app's query composition path, even though Pixiv users commonly expect that input style.

## What changed
- restored browse history taps and kept the related search navigation path working reliably again
- stabilized the search history clear action and anchored its confirmation UI to the correct presentation context
- changed search history rendering to store and display plain queries instead of the older prefixed format
- fixed multi-tag query composition so space-separated input is treated as normal text while still producing the intended Pixiv search behavior
- removed a stale search suggestion callback that no longer matched the updated search flow
- restored novel comment navigation that had regressed alongside the related history/search changes

## Result
- search history behaves predictably again: entries open, clearing works consistently, and the confirmation UI appears in the right place
- multi-tag searches are easier to enter and behave more like users expect
- related navigation regressions, including novel comment entry, are resolved

## Testing
- passed GitHub Actions CI build in the fork while validating the patch series that includes this change
- manually verified search history interactions, multi-tag search behavior, and novel comment navigation on iPhone
