### PR TITLE
refactor: unify novel list presentation

### DIFF
--- a/Pixiv-SwiftUI/Features/Novel/Components/NovelRankingPreview.swift
+++ b/Pixiv-SwiftUI/Features/Novel/Components/NovelRankingPreview.swift
@@ -63,51 +63,60 @@ struct NovelRankingPreview: View {
 }
 
 struct NovelRankingCard: View {
+    private enum Layout {
+        static let contentWidth: CGFloat = 100
+        static let cardWidth: CGFloat = 120
+        static let imageSize: CGFloat = 100
+    }
+
     let novel: Novel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 8) {
             CachedAsyncImage(
                 urlString: novel.imageUrls.medium,
                 expiration: DefaultCacheExpiration.novel
             )
-            .frame(width: 100, height: 100)
+            .frame(width: Layout.imageSize, height: Layout.imageSize)
             .clipShape(RoundedRectangle(cornerRadius: 8))
 
-            Text(novel.title)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundColor(.primary)
-                .lineLimit(2)
-                .frame(width: 100, alignment: .leading)
-                .multilineTextAlignment(.leading)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(novel.title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+                    .lineLimit(2, reservesSpace: true)
+                    .frame(width: Layout.contentWidth, alignment: .leading)
+                    .multilineTextAlignment(.leading)
 
-            Text(novel.user.name)
-                .font(.caption2)
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .frame(width: 100, alignment: .leading)
-
-            HStack(spacing: 2) {
-                Text(formatTextLength(novel.textLength))
-                    .font(.caption2)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-
-                Spacer()
-
-                Image(systemName: novel.isBookmarked ? "heart.fill" : "heart")
-                    .foregroundColor(novel.isBookmarked ? .red : .secondary)
-                    .font(.system(size: 10))
-                Text(NumberFormatter.formatCount(novel.totalBookmarks))
+                Text(novel.user.name)
                     .font(.caption2)
                     .foregroundColor(.secondary)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+                    .frame(width: Layout.contentWidth, alignment: .leading)
+
+                HStack(spacing: 2) {
+                    Text(formatTextLength(novel.textLength))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+
+                    Spacer()
+
+                    Image(systemName: novel.isBookmarked ? "heart.fill" : "heart")
+                        .foregroundColor(novel.isBookmarked ? .red : .secondary)
+                        .font(.system(size: 10))
+                    Text(NumberFormatter.formatCount(novel.totalBookmarks))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+                .frame(width: Layout.contentWidth)
             }
-            .frame(width: 100)
         }
-        .frame(width: 120)
+        .frame(width: Layout.cardWidth)
     }
 
     private func formatTextLength(_ length: Int) -> String {

--- a/Pixiv-SwiftUI/Features/Novel/Components/NovelRankingPreview.swift
+++ b/Pixiv-SwiftUI/Features/Novel/Components/NovelRankingPreview.swift
@@ -89,19 +89,21 @@ struct NovelRankingCard: View {
                 .frame(width: 100, alignment: .leading)
 
             HStack(spacing: 2) {
-                Image(systemName: "text.alignleft")
-                    .font(.system(size: 10))
                 Text(formatTextLength(novel.textLength))
                     .font(.caption2)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
 
                 Spacer()
 
                 Image(systemName: novel.isBookmarked ? "heart.fill" : "heart")
                     .foregroundColor(novel.isBookmarked ? .red : .secondary)
                     .font(.system(size: 10))
-                Text("\(novel.totalBookmarks)")
+                Text(NumberFormatter.formatCount(novel.totalBookmarks))
                     .font(.caption2)
                     .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
             .frame(width: 100)
         }

--- a/Pixiv-SwiftUI/Features/Novel/NovelRankingPage.swift
+++ b/Pixiv-SwiftUI/Features/Novel/NovelRankingPage.swift
@@ -121,87 +121,12 @@ struct NovelRankingListRow: View {
     let novel: Novel
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            CachedAsyncImage(
-                urlString: novel.imageUrls.medium,
-                expiration: DefaultCacheExpiration.novel
-            )
-            .frame(width: 80, height: 80)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(novel.title)
-                    .font(.body)
-                    .fontWeight(.medium)
-                    .lineLimit(3)
-                    .multilineTextAlignment(.leading)
-                    .foregroundColor(.primary)
-
-                HStack(spacing: 4) {
-                    Text(novel.user.name)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-
-                    HStack(spacing: 2) {
-                        Image(systemName: "text.alignleft")
-                            .font(.system(size: 10))
-                        Text(formatTextLength(novel.textLength))
-                            .font(.caption)
-                    }
-                    .foregroundColor(.secondary)
-                }
-
-                if !novel.tags.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 4) {
-                            ForEach(novel.tags.prefix(5)) { tag in
-                                Text(tag.name)
-                                    .font(.caption2)
-                                    .foregroundColor(.secondary)
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(Color.secondary.opacity(0.1))
-                                    .cornerRadius(4)
-                            }
-                        }
-                    }
-                }
-            }
-
-            Spacer()
-
-            VStack(spacing: 4) {
-                Image(systemName: novel.isBookmarked ? "heart.fill" : "heart")
-                    .foregroundColor(novel.isBookmarked ? .red : .secondary)
-                    .font(.system(size: 18))
-
-                Text("\(novel.totalBookmarks)")
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-            }
-            .frame(width: 40)
-        }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 12)
-        #if os(macOS)
-        .background(Color(nsColor: .controlBackgroundColor))
-        #else
-        .background(Color(uiColor: .systemBackground))
-        #endif
-    }
-
-    private func formatTextLength(_ length: Int) -> String {
-        if length >= 10000 {
-            let value = Double(length) / 10000
-            let formatted = String(format: "%.1f", value)
-            return "\(formatted) " + String(localized: "万字")
-        } else if length >= 1000 {
-            let value = Double(length) / 1000
-            let formatted = String(format: "%.1f", value)
-            return "\(formatted) " + String(localized: "千字")
-        }
-        return "\(length) " + String(localized: "字")
+        NovelInfoTableRow(
+            novel: novel,
+            detailStyle: .author,
+            showsBookmarkSummary: true,
+            bookmarkSummaryText: NumberFormatter.formatCount(novel.totalBookmarks)
+        )
     }
 }
 

--- a/Pixiv-SwiftUI/Features/User/NovelWaterfallView.swift
+++ b/Pixiv-SwiftUI/Features/User/NovelWaterfallView.swift
@@ -40,78 +40,12 @@ struct NovelWaterfallView: View {
 struct NovelRowView: View {
     let novel: Novel
 
-    private func formatTextLength(_ length: Int) -> String {
-        if length >= 10000 {
-            return String(format: "%.1f万字", Double(length) / 10000)
-        } else if length >= 1000 {
-            return String(format: "%.1f千字", Double(length) / 1000)
-        }
-        return "\(length)字"
-    }
-
     var body: some View {
         NavigationLink(value: novel) {
-            HStack(alignment: .top, spacing: 12) {
-                CachedAsyncImage(
-                    urlString: novel.imageUrls.medium,
-                    expiration: DefaultCacheExpiration.novel
-                )
-                .frame(width: 80, height: 80)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(novel.title)
-                        .font(.headline)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.leading)
-
-                    Text(novel.user.name)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-
-                    HStack(spacing: 8) {
-                        Label(formatTextLength(novel.textLength), systemImage: "text.alignleft")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-
-                        HStack(spacing: 2) {
-                            Image(systemName: novel.isBookmarked ? "heart.fill" : "heart")
-                                .foregroundColor(novel.isBookmarked ? .red : .secondary)
-                                .font(.caption2)
-                            Text("\(novel.totalBookmarks)")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                        }
-
-                        HStack(spacing: 2) {
-                            Image(systemName: "eye")
-                                .foregroundColor(.secondary)
-                                .font(.caption2)
-                            Text("\(novel.totalView)")
-                                .font(.caption2)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-
-                    if !novel.tags.isEmpty {
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 4) {
-                                ForEach(novel.tags.prefix(5)) { tag in
-                                    Text(tag.name)
-                                        .font(.caption2)
-                                        .padding(.horizontal, 6)
-                                        .padding(.vertical, 2)
-                                        .background(Color.gray.opacity(0.2))
-                                        .clipShape(Capsule())
-                                }
-                            }
-                        }
-                    }
-                }
-
-                Spacer(minLength: 0)
-            }
+            NovelInfoTableRow(
+                novel: novel,
+                detailStyle: .metrics
+            )
         }
         .buttonStyle(.plain)
     }

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelCard.swift
@@ -36,19 +36,21 @@ struct NovelCard: View {
                 .frame(width: 100, alignment: .leading)
 
             HStack(spacing: 2) {
-                Image(systemName: "text.alignleft")
-                    .font(.system(size: 10))
                 Text(formatTextLength(novel.textLength))
                     .font(.caption2)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
 
                 Spacer()
 
                 Image(systemName: isBookmarked ? "heart.fill" : "heart")
                     .foregroundColor(isBookmarked ? .red : .secondary)
                     .font(.system(size: 10))
-                Text("\(novel.totalBookmarks)")
+                Text(NumberFormatter.formatCount(novel.totalBookmarks))
                     .font(.caption2)
                     .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
             }
             .frame(width: 100)
         }

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelCard.swift
@@ -1,6 +1,12 @@
 import SwiftUI
 
 struct NovelCard: View {
+    private enum Layout {
+        static let contentWidth: CGFloat = 100
+        static let cardWidth: CGFloat = 120
+        static let imageSize: CGFloat = 100
+    }
+
     #if os(macOS)
     @Environment(\.openWindow) var openWindow
     #endif
@@ -19,42 +25,45 @@ struct NovelCard: View {
                 urlString: novel.imageUrls.medium,
                 expiration: DefaultCacheExpiration.novel
             )
-            .frame(width: 100, height: 100)
+            .frame(width: Layout.imageSize, height: Layout.imageSize)
             .clipShape(RoundedRectangle(cornerRadius: 8))
 
-            Text(novel.title)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .lineLimit(2)
-                .frame(width: 100, alignment: .leading)
-                .multilineTextAlignment(.leading)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(novel.title)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .lineLimit(2, reservesSpace: true)
+                    .frame(width: Layout.contentWidth, alignment: .leading)
+                    .multilineTextAlignment(.leading)
 
-            Text(novel.user.name)
-                .font(.caption2)
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .frame(width: 100, alignment: .leading)
-
-            HStack(spacing: 2) {
-                Text(formatTextLength(novel.textLength))
-                    .font(.caption2)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-
-                Spacer()
-
-                Image(systemName: isBookmarked ? "heart.fill" : "heart")
-                    .foregroundColor(isBookmarked ? .red : .secondary)
-                    .font(.system(size: 10))
-                Text(NumberFormatter.formatCount(novel.totalBookmarks))
+                Text(novel.user.name)
                     .font(.caption2)
                     .foregroundColor(.secondary)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+                    .frame(width: Layout.contentWidth, alignment: .leading)
+
+                HStack(spacing: 2) {
+                    Text(formatTextLength(novel.textLength))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+
+                    Spacer()
+
+                    Image(systemName: isBookmarked ? "heart.fill" : "heart")
+                        .foregroundColor(isBookmarked ? .red : .secondary)
+                        .font(.system(size: 10))
+                    Text(NumberFormatter.formatCount(novel.totalBookmarks))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                }
+                .frame(width: Layout.contentWidth)
             }
-            .frame(width: 100)
         }
-        .frame(width: 120)
+        .frame(width: Layout.cardWidth)
         .contextMenu {
             #if os(macOS)
             Button {

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelInfoTableRow.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelInfoTableRow.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+enum NovelInfoDetailStyle {
+    case author
+    case metrics
+}
+
+struct NovelInfoTableRow: View {
+    let novel: Novel
+    var titlePrefix: String?
+    var detailStyle: NovelInfoDetailStyle = .author
+    var showsBookmarkSummary = false
+    var isBookmarked: Bool? = nil
+    var bookmarkSummaryText: String? = nil
+
+    private var resolvedIsBookmarked: Bool {
+        isBookmarked ?? novel.isBookmarked
+    }
+
+    private var resolvedBookmarkSummaryText: String {
+        bookmarkSummaryText ?? NumberFormatter.formatCount(novel.totalBookmarks)
+    }
+
+    private var titleText: String {
+        if let titlePrefix, !titlePrefix.isEmpty {
+            return "\(titlePrefix)\(novel.title)"
+        }
+        return novel.title
+    }
+
+    private var tagSummary: String {
+        let tags = novel.tags.prefix(4).map(\.name)
+        if tags.isEmpty {
+            return "—"
+        }
+        return tags.joined(separator: " / ")
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            CachedAsyncImage(
+                urlString: novel.imageUrls.medium,
+                expiration: DefaultCacheExpiration.novel
+            )
+            .frame(width: 80, height: 80)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            Grid(alignment: .topLeading, horizontalSpacing: 12, verticalSpacing: 6) {
+                GridRow {
+                    titleColumn
+                        .gridCellColumns(2)
+
+                    detailColumn
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    tagColumn
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if showsBookmarkSummary {
+                bookmarkColumn
+                    .frame(width: 44)
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+    }
+
+    private var titleColumn: some View {
+        Text(titleText)
+            .font(.body)
+            .fontWeight(.medium)
+            .foregroundColor(.primary)
+            .lineLimit(3)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var detailColumn: some View {
+        switch detailStyle {
+        case .author:
+            Text(novel.user.name)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+        case .metrics:
+            VStack(alignment: .leading, spacing: 4) {
+                Text(formatTextLength(novel.textLength))
+                Text("\(NumberFormatter.formatCount(novel.totalBookmarks))收藏")
+                Text("\(NumberFormatter.formatCount(novel.totalView))阅读")
+            }
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+        }
+    }
+
+    private var tagColumn: some View {
+        Text(tagSummary)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .lineLimit(3)
+            .multilineTextAlignment(.leading)
+    }
+
+    private var bookmarkColumn: some View {
+        VStack(spacing: 4) {
+            Image(systemName: resolvedIsBookmarked ? "heart.fill" : "heart")
+                .foregroundColor(resolvedIsBookmarked ? .red : .secondary)
+                .font(.system(size: 18))
+
+            Text(resolvedBookmarkSummaryText)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+    }
+
+    private func formatTextLength(_ length: Int) -> String {
+        if length >= 10000 {
+            return String(format: "%.1f万字", Double(length) / 10000)
+        } else if length >= 1000 {
+            return String(format: "%.1f千字", Double(length) / 1000)
+        }
+        return "\(length)字"
+    }
+}

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelInfoTableRow.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelInfoTableRow.swift
@@ -36,6 +36,10 @@ struct NovelInfoTableRow: View {
         return tags.joined(separator: " / ")
     }
 
+    private var metricsSummary: String {
+        "\(formatTextLength(novel.textLength)) / \(NumberFormatter.formatCount(novel.totalBookmarks))收藏 / \(NumberFormatter.formatCount(novel.totalView))阅读"
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
             CachedAsyncImage(
@@ -45,17 +49,10 @@ struct NovelInfoTableRow: View {
             .frame(width: 80, height: 80)
             .clipShape(RoundedRectangle(cornerRadius: 8))
 
-            Grid(alignment: .topLeading, horizontalSpacing: 12, verticalSpacing: 6) {
-                GridRow {
-                    titleColumn
-                        .gridCellColumns(2)
-
-                    detailColumn
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                    tagColumn
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+            VStack(alignment: .leading, spacing: 4) {
+                titleColumn
+                detailColumn
+                tagColumn
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -73,7 +70,7 @@ struct NovelInfoTableRow: View {
             .font(.body)
             .fontWeight(.medium)
             .foregroundColor(.primary)
-            .lineLimit(3)
+            .lineLimit(2, reservesSpace: true)
             .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -85,17 +82,14 @@ struct NovelInfoTableRow: View {
             Text(novel.user.name)
                 .font(.caption)
                 .foregroundColor(.secondary)
-                .lineLimit(2)
+                .lineLimit(1, reservesSpace: true)
                 .multilineTextAlignment(.leading)
         case .metrics:
-            VStack(alignment: .leading, spacing: 4) {
-                Text(formatTextLength(novel.textLength))
-                Text("\(NumberFormatter.formatCount(novel.totalBookmarks))收藏")
-                Text("\(NumberFormatter.formatCount(novel.totalView))阅读")
-            }
+            Text(metricsSummary)
             .font(.caption)
             .foregroundColor(.secondary)
             .lineLimit(1)
+            .minimumScaleFactor(0.8)
         }
     }
 
@@ -103,7 +97,7 @@ struct NovelInfoTableRow: View {
         Text(tagSummary)
             .font(.caption)
             .foregroundColor(.secondary)
-            .lineLimit(3)
+            .lineLimit(1, reservesSpace: true)
             .multilineTextAlignment(.leading)
     }
 

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelInfoTableRow.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelInfoTableRow.swift
@@ -6,6 +6,11 @@ enum NovelInfoDetailStyle {
 }
 
 struct NovelInfoTableRow: View {
+    private enum Layout {
+        static let thumbnailSize: CGFloat = 80
+        static let tagRowHeight: CGFloat = 22
+    }
+
     let novel: Novel
     var titlePrefix: String?
     var detailStyle: NovelInfoDetailStyle = .author
@@ -28,14 +33,6 @@ struct NovelInfoTableRow: View {
         return novel.title
     }
 
-    private var tagSummary: String {
-        let tags = novel.tags.prefix(4).map(\.name)
-        if tags.isEmpty {
-            return "—"
-        }
-        return tags.joined(separator: " / ")
-    }
-
     private var metricsSummary: String {
         "\(formatTextLength(novel.textLength)) / \(NumberFormatter.formatCount(novel.totalBookmarks))收藏 / \(NumberFormatter.formatCount(novel.totalView))阅读"
     }
@@ -46,7 +43,7 @@ struct NovelInfoTableRow: View {
                 urlString: novel.imageUrls.medium,
                 expiration: DefaultCacheExpiration.novel
             )
-            .frame(width: 80, height: 80)
+            .frame(width: Layout.thumbnailSize, height: Layout.thumbnailSize)
             .clipShape(RoundedRectangle(cornerRadius: 8))
 
             VStack(alignment: .leading, spacing: 4) {
@@ -54,7 +51,7 @@ struct NovelInfoTableRow: View {
                 detailColumn
                 tagColumn
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: Layout.thumbnailSize, alignment: .topLeading)
 
             if showsBookmarkSummary {
                 bookmarkColumn
@@ -84,21 +81,42 @@ struct NovelInfoTableRow: View {
                 .foregroundColor(.secondary)
                 .lineLimit(1, reservesSpace: true)
                 .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
         case .metrics:
             Text(metricsSummary)
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .lineLimit(1)
-            .minimumScaleFactor(0.8)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
+    @ViewBuilder
     private var tagColumn: some View {
-        Text(tagSummary)
-            .font(.caption)
-            .foregroundColor(.secondary)
-            .lineLimit(1, reservesSpace: true)
-            .multilineTextAlignment(.leading)
+        if novel.tags.isEmpty {
+            Text("—")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .lineLimit(1, reservesSpace: true)
+                .frame(maxWidth: .infinity, minHeight: Layout.tagRowHeight, alignment: .leading)
+        } else {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    ForEach(novel.tags.prefix(4), id: \.name) { tag in
+                        Text(tag.name)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Color.secondary.opacity(0.1))
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: Layout.tagRowHeight, maxHeight: Layout.tagRowHeight, alignment: .leading)
+        }
     }
 
     private var bookmarkColumn: some View {

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelListCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelListCard.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct NovelListCard: View {
-    @Environment(\.colorScheme) var colorScheme
     #if os(macOS)
     @Environment(\.openWindow) var openWindow
     #endif
@@ -17,70 +16,13 @@ struct NovelListCard: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            CachedAsyncImage(
-                urlString: novel.imageUrls.medium,
-                expiration: DefaultCacheExpiration.novel
-            )
-            .frame(width: 80, height: 80)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(novel.title)
-                    .font(.body)
-                    .fontWeight(.medium)
-                    .lineLimit(3)
-                    .multilineTextAlignment(.leading)
-
-                HStack(spacing: 4) {
-                    Text(novel.user.name)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-
-                    HStack(spacing: 2) {
-                        Image(systemName: "text.alignleft")
-                            .font(.system(size: 10))
-                        Text(formatTextLength(novel.textLength))
-                            .font(.caption)
-                    }
-                    .foregroundColor(.secondary)
-                }
-
-                if !novel.tags.isEmpty {
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 4) {
-                            ForEach(novel.tags.prefix(5)) { tag in
-                                Text(tag.name)
-                                    .font(.caption2)
-                                    .foregroundColor(.primary)
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(Color.gray.opacity(colorScheme == .dark ? 0.2 : 0.1))
-                                    .cornerRadius(4)
-                            }
-                        }
-                    }
-                }
-            }
-
-            Spacer()
-
-            VStack(spacing: 4) {
-                Image(systemName: isBookmarked ? "heart.fill" : "heart")
-                    .foregroundColor(isBookmarked ? .red : .secondary)
-                    .font(.system(size: 18))
-
-                if showsBookmarkCount {
-                    Text("\(novel.totalBookmarks)")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            }
-            .frame(width: 40)
-        }
-        .padding(.vertical, 8)
-        .padding(.horizontal, 12)
+        NovelInfoTableRow(
+            novel: novel,
+            detailStyle: .author,
+            showsBookmarkSummary: showsBookmarkCount,
+            isBookmarked: isBookmarked,
+            bookmarkSummaryText: NumberFormatter.formatCount(novel.totalBookmarks)
+        )
         .contextMenu {
             #if os(macOS)
             Button {
@@ -163,15 +105,6 @@ struct NovelListCard: View {
                 }
             }
         }
-    }
-
-    private func formatTextLength(_ length: Int) -> String {
-        if length >= 10000 {
-            return String(format: "%.1f万字", Double(length) / 10000)
-        } else if length >= 1000 {
-            return String(format: "%.1f千字", Double(length) / 1000)
-        }
-        return "\(length)字"
     }
 
     private func toggleBookmark(isPrivate: Bool = false, forceUnbookmark: Bool = false) {

--- a/Pixiv-SwiftUI/Shared/Components/Cards/NovelSeriesCard.swift
+++ b/Pixiv-SwiftUI/Shared/Components/Cards/NovelSeriesCard.swift
@@ -35,12 +35,10 @@ struct NovelSeriesCard: View {
                     .foregroundColor(.secondary)
 
                 HStack(spacing: 12) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "text.alignleft")
-                            .font(.caption2)
-                        Text(formatTextLength(novel.textLength))
-                            .font(.caption)
-                    }
+                    Text(formatTextLength(novel.textLength))
+                        .font(.caption)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
 
                     HStack(spacing: 4) {
                         Image(systemName: isBookmarked ? "heart.fill" : "heart")


### PR DESCRIPTION
## Why
The novel surfaces updated in this patch series needed a more consistent presentation. Metadata placement had drifted across ranking, related lists, and author novel lists, and long stat labels could wrap awkwardly, making rows harder to scan.

This was especially noticeable on iPhone, where compact spacing makes inconsistent title, tag, and stat layout much more obvious.

## What changed
- introduced a shared novel info row component for the affected list surfaces
- aligned ranking, related, and author novel rows around the same stacked structure
- kept title space stable while tightening the remaining metadata layout
- compacted stat label rendering to avoid awkward wrapping in constrained widths
- polished card spacing and thumbnail-to-text alignment for the updated novel list presentation

## Result
- the affected novel list surfaces now read more consistently
- title, tags, and stats are easier to scan on iPhone
- compact novel metadata no longer wraps as awkwardly in common list layouts

## Testing
- passed GitHub Actions CI build in the fork while validating the patch series that includes this change
- manually verified the updated novel list layouts across ranking, related novel lists, and author novel lists on iPhone
