### PR TITLE
fix: load user settings after account restore

### DIFF
--- a/Pixiv-SwiftUI/Core/Services/AppInitializer.swift
+++ b/Pixiv-SwiftUI/Core/Services/AppInitializer.swift
@@ -28,11 +28,9 @@ final class AppInitializer {
         let uStore = UserSettingStore.shared
 
         // 3. 异步加载持久化数据
-        // 并行加载账户和设置
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask { await aStore.loadAccountsAsync() }
-            group.addTask { await uStore.loadUserSettingAsync() }
-        }
+        // 用户设置依赖当前账户 ownerId，必须在账户恢复后再加载。
+        await aStore.loadAccountsAsync()
+        await uStore.loadUserSettingAsync()
 
         // 4. 账户加载完成后，主动刷新已过期的 token（启动画面期间进行）
         if aStore.isLoggedIn {


### PR DESCRIPTION
## Summary
Load persisted user settings only after account restoration finishes during app startup.

## Why
`AppInitializer.performInitialization()` currently restores accounts and user settings in parallel. `UserSettingStore.loadUserSettingAsync()` resolves the settings record by `AccountStore.shared.currentUserId`, so when account restoration has not finished yet it can load settings for the wrong owner or create a new default record.

A concrete failure case is saving novel blacklist settings after relaunch: the app can appear to accept the change, but the updated blacklist ends up attached to the wrong settings record, so the blocked title/series/caption rules look like they were not persisted when the app is opened again.

## What Changed
- restore accounts before loading user settings during startup
- keep the rest of the initialization flow unchanged

## Result
- the restored account's settings are loaded against the correct `ownerId`
- settings no longer appear to reset after relaunch or account restore

## Testing
- compiled successfully in the fork's workflow
- verified on iPhone that the account restore / relaunch flow behaves correctly
