### PR TITLE
fix: recover novel search pagination after local filtering

### DIFF
--- a/Pixiv-SwiftUI/Core/State/Stores/SearchResultStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/SearchResultStore.swift
@@ -113,6 +113,7 @@ final class SearchResultStore {
     var novelLimit: Int = 30
     var novelHasMore: Bool = false
     var isLoadingMoreNovels: Bool = false
+    var novelLoadMoreErrorMessage: String?
 
     @ObservationIgnored private let api = PixivAPI.shared
     @ObservationIgnored private let pseudoPopularInitialSamplePageCount = 1
@@ -589,6 +590,7 @@ final class SearchResultStore {
         guard !isLoading else { return }
         isLoading = true
         errorMessage = nil
+        novelLoadMoreErrorMessage = nil
         self.novelPseudoPopularTargetCount = 0
         self.novelPseudoPopularSamplePageCount = 0
         self.novelPseudoPopularSessionID = UUID()
@@ -676,6 +678,7 @@ final class SearchResultStore {
     ) async {
         guard !isLoading, !isLoadingMoreNovels, novelHasMore else { return }
         isLoadingMoreNovels = true
+        novelLoadMoreErrorMessage = nil
         let baseWord = normalizeSearchWord(word)
         let usesPseudoPopularSort = preferLocalPopularSort && sort == SearchSortOption.popularDesc.rawValue
         let usesUsersTagPseudoPopularSort = usesPseudoPopularSort && searchTarget != .titleAndCaption
@@ -767,6 +770,7 @@ final class SearchResultStore {
             }
         } catch {
             print("Failed to load more novels: \(error)")
+            novelLoadMoreErrorMessage = error.localizedDescription
         }
         isLoadingMoreNovels = false
     }

--- a/Pixiv-SwiftUI/Features/Search/SearchResultView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchResultView.swift
@@ -20,6 +20,8 @@ private struct SearchFilterState: Equatable {
 }
 
 struct SearchResultView: View {
+    private let novelAutoLoadBurstLimit = 5
+
     let word: String
     let preloadToken: UUID?
     @State var store = SearchResultStore()
@@ -27,6 +29,8 @@ struct SearchResultView: View {
     @State private var sortOption: SearchSortOption = SearchSortOption(rawValue: UserSettingStore.shared.userSetting.defaultSearchSort) ?? .dateDesc
     @State private var novelSortOption: SearchSortOption = SearchSortOption(rawValue: UserSettingStore.shared.userSetting.defaultSearchSort) ?? .dateDesc
     @State private var filterState = SearchFilterState()
+    @State private var isResolvingNovelLoadMore = false
+    @State private var isNovelLoadMorePaused = false
     @Environment(UserSettingStore.self) var settingStore
     @Environment(AccountStore.self) var accountStore
     @Environment(ThemeManager.self) var themeManager
@@ -99,6 +103,7 @@ struct SearchResultView: View {
     }
 
     private func performNovelSearch() async {
+        isNovelLoadMorePaused = false
         await store.searchNovels(
             word: word,
             sort: novelSortOption.rawValue,
@@ -146,6 +151,45 @@ struct SearchResultView: View {
         )
     }
 
+    @MainActor
+    private func loadMoreNovelResultsRespectingFilters(forceManualContinuation: Bool = false) async {
+        if forceManualContinuation {
+            isNovelLoadMorePaused = false
+        }
+
+        guard !isResolvingNovelLoadMore, !isNovelLoadMorePaused else { return }
+
+        let initialVisibleCount = filteredNovels.count
+        isResolvingNovelLoadMore = true
+        defer {
+            isResolvingNovelLoadMore = false
+        }
+
+        var attempts = 0
+
+        while store.novelHasMore && attempts < novelAutoLoadBurstLimit {
+            let totalCountBeforeLoad = store.novelResults.count
+            await loadMoreNovelResults()
+            attempts += 1
+
+            if store.novelLoadMoreErrorMessage != nil || !store.novelHasMore {
+                return
+            }
+
+            if filteredNovels.count > initialVisibleCount {
+                return
+            }
+
+            if store.novelResults.count <= totalCountBeforeLoad {
+                break
+            }
+        }
+
+        if store.novelHasMore && filteredNovels.count == initialVisibleCount && store.novelLoadMoreErrorMessage == nil {
+            isNovelLoadMorePaused = true
+        }
+    }
+
     @ViewBuilder
     private var novelLoadMoreFooter: some View {
         if let errorMessage = store.novelLoadMoreErrorMessage {
@@ -167,13 +211,32 @@ struct SearchResultView: View {
                 .buttonStyle(.bordered)
             }
             .padding()
+        } else if isNovelLoadMorePaused {
+            VStack(spacing: 8) {
+                Text("已连续跳过多页被屏蔽内容")
+                    .font(.subheadline)
+                    .foregroundColor(.primary)
+
+                Text("继续加载会再向后查找可显示的小说")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Button("继续加载") {
+                    Task {
+                        await loadMoreNovelResultsRespectingFilters(forceManualContinuation: true)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
         } else {
             ProgressView()
                 .padding()
                 .id("novel-load-more-\(store.novelResults.count)")
                 .onAppear {
                     Task {
-                        await loadMoreNovelResults()
+                        await loadMoreNovelResultsRespectingFilters()
                     }
                 }
         }

--- a/Pixiv-SwiftUI/Features/Search/SearchResultView.swift
+++ b/Pixiv-SwiftUI/Features/Search/SearchResultView.swift
@@ -147,6 +147,39 @@ struct SearchResultView: View {
     }
 
     @ViewBuilder
+    private var novelLoadMoreFooter: some View {
+        if let errorMessage = store.novelLoadMoreErrorMessage {
+            VStack(spacing: 8) {
+                Text("加载更多失败")
+                    .font(.subheadline)
+                    .foregroundColor(.primary)
+
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+
+                Button("重试") {
+                    Task {
+                        await loadMoreNovelResults()
+                    }
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding()
+        } else {
+            ProgressView()
+                .padding()
+                .id("novel-load-more-\(store.novelResults.count)")
+                .onAppear {
+                    Task {
+                        await loadMoreNovelResults()
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
     private func resultContent(columnCount: Int, waterfallWidth: CGFloat?, userColumnCount: Int) -> some View {
         if store.isLoading && store.illustResults.isEmpty && store.novelResults.isEmpty && store.userResults.isEmpty {
             SkeletonIllustWaterfallGrid(
@@ -267,16 +300,11 @@ struct SearchResultView: View {
         if filteredNovels.isEmpty && !store.novelResults.isEmpty && !store.isLoading {
             if store.novelHasMore {
                 VStack(spacing: 12) {
-                    ProgressView()
-                        .onAppear {
-                            Task {
-                                await loadMoreNovelResults()
-                            }
-                        }
-
                     Text("正在加载更多结果")
                         .font(.caption)
                         .foregroundColor(.secondary)
+
+                    novelLoadMoreFooter
                 }
                 .frame(minHeight: 300)
             } else {
@@ -311,16 +339,7 @@ struct SearchResultView: View {
                 }
 
                 if store.novelHasMore {
-                    ProgressView()
-                        #if os(macOS)
-                        .controlSize(.small)
-                        #endif
-                        .padding()
-                        .onAppear {
-                            Task {
-                                await loadMoreNovelResults()
-                            }
-                        }
+                    novelLoadMoreFooter
                 } else if !filteredNovels.isEmpty {
                     Text(String(localized: "已经到底了"))
                         .font(.caption)


### PR DESCRIPTION
## Summary
Improve novel search pagination recovery when local blacklist rules hide large portions of the fetched results.

## Why
Novel search results are filtered locally after the API response is loaded. When many fetched novels are hidden by local blacklist rules, the result list can shrink to zero visible items even though `novelHasMore` is still true. In that state the footer keeps trying to load more pages, and the view can get stuck showing an endless spinner with no visible progress.

## What Changed
- surface novel load-more errors in `SearchResultStore` instead of silently swallowing them
- replace the bare novel footer spinner with a retryable footer state
- keep loading additional pages while the newly fetched page is still fully filtered out locally
- stop the automatic burst after several fully filtered pages and switch to an explicit continue action instead of spinning forever

## Result
- novel search can recover when a page is dominated by locally blocked content
- failed pagination requests are visible and retryable
- the footer no longer gets stuck in an infinite loading state when every newly fetched page is filtered out

## Testing
- compiled successfully in the fork's workflow
- verified on iPhone with novel searches that contain large amounts of blacklisted content
