### PR TITLE
fix: use next_url for regular search pagination

### DIFF
--- a/Pixiv-SwiftUI/Core/Network/API/AppAPI/SearchAPI.swift
+++ b/Pixiv-SwiftUI/Core/Network/API/AppAPI/SearchAPI.swift
@@ -114,6 +114,30 @@ final class SearchAPI {
         offset: Int = 0,
         limit: Int = 30
     ) async throws -> [Illusts] {
+        let response = try await searchIllustsPage(
+            word: word,
+            searchTarget: searchTarget,
+            sort: sort,
+            searchAIType: searchAIType,
+            startDate: startDate,
+            endDate: endDate,
+            offset: offset,
+            limit: limit
+        )
+
+        return response.illusts
+    }
+
+    func searchIllustsPage(
+        word: String,
+        searchTarget: String = "partial_match_for_tags",
+        sort: String = "date_desc",
+        searchAIType: Int? = nil,
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        offset: Int = 0,
+        limit: Int = 30
+    ) async throws -> IllustsResponse {
         var components = URLComponents(string: APIEndpoint.baseURL + APIEndpoint.searchIllust)
         var queryItems = [
             URLQueryItem(name: "word", value: word),
@@ -141,17 +165,11 @@ final class SearchAPI {
             throw NetworkError.invalidResponse
         }
 
-        struct Response: Decodable {
-            let illusts: [Illusts]
-        }
-
-        let response = try await client.get(
+        return try await client.get(
             from: url,
             headers: authHeaders,
-            responseType: Response.self
+            responseType: IllustsResponse.self
         )
-
-        return response.illusts
     }
 
     /// 获取搜索建议
@@ -197,6 +215,30 @@ final class SearchAPI {
         offset: Int = 0,
         limit: Int = 30
     ) async throws -> [Novel] {
+        let response = try await searchNovelsPage(
+            word: word,
+            searchTarget: searchTarget,
+            sort: sort,
+            searchAIType: searchAIType,
+            startDate: startDate,
+            endDate: endDate,
+            offset: offset,
+            limit: limit
+        )
+
+        return response.novels
+    }
+
+    func searchNovelsPage(
+        word: String,
+        searchTarget: String = "partial_match_for_tags",
+        sort: String = "date_desc",
+        searchAIType: Int? = nil,
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        offset: Int = 0,
+        limit: Int = 30
+    ) async throws -> NovelResponse {
         var components = URLComponents(string: APIEndpoint.baseURL + "/v1/search/novel")
         var queryItems = [
             URLQueryItem(name: "word", value: word),
@@ -226,17 +268,11 @@ final class SearchAPI {
             throw NetworkError.invalidResponse
         }
 
-        struct Response: Decodable {
-            let novels: [Novel]
-        }
-
-        let response = try await client.get(
+        return try await client.get(
             from: url,
             headers: authHeaders,
-            responseType: Response.self
+            responseType: NovelResponse.self
         )
-
-        return response.novels
     }
 
     private func formatDate(_ date: Date?) -> String? {

--- a/Pixiv-SwiftUI/Core/Network/PixivAPI.swift
+++ b/Pixiv-SwiftUI/Core/Network/PixivAPI.swift
@@ -235,6 +235,29 @@ final class PixivAPI {
         )
     }
 
+    func searchIllustsPage(
+        word: String,
+        searchTarget: String = "partial_match_for_tags",
+        sort: String = "date_desc",
+        searchAIType: Int? = nil,
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        offset: Int = 0,
+        limit: Int = 30
+    ) async throws -> IllustsResponse {
+        guard let api = searchAPI else { throw NetworkError.invalidResponse }
+        return try await api.searchIllustsPage(
+            word: word,
+            searchTarget: searchTarget,
+            sort: sort,
+            searchAIType: searchAIType,
+            startDate: startDate,
+            endDate: endDate,
+            offset: offset,
+            limit: limit
+        )
+    }
+
     // MARK: - 插画相关
 
     /// 获取推荐插画
@@ -494,6 +517,29 @@ final class PixivAPI {
     ) async throws -> [Novel] {
         guard let api = searchAPI else { throw NetworkError.invalidResponse }
         return try await api.searchNovels(
+            word: word,
+            searchTarget: searchTarget,
+            sort: sort,
+            searchAIType: searchAIType,
+            startDate: startDate,
+            endDate: endDate,
+            offset: offset,
+            limit: limit
+        )
+    }
+
+    func searchNovelsPage(
+        word: String,
+        searchTarget: String = "partial_match_for_tags",
+        sort: String = "date_desc",
+        searchAIType: Int? = nil,
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        offset: Int = 0,
+        limit: Int = 30
+    ) async throws -> NovelResponse {
+        guard let api = searchAPI else { throw NetworkError.invalidResponse }
+        return try await api.searchNovelsPage(
             word: word,
             searchTarget: searchTarget,
             sort: sort,

--- a/Pixiv-SwiftUI/Core/State/Stores/SearchResultStore.swift
+++ b/Pixiv-SwiftUI/Core/State/Stores/SearchResultStore.swift
@@ -98,6 +98,8 @@ final class SearchResultStore {
 
     var isLoading: Bool = false
     var errorMessage: String?
+    @ObservationIgnored private var illustNextURL: String?
+    @ObservationIgnored private var novelNextURL: String?
 
     // 分页状态
     var illustOffset: Int = 0
@@ -168,6 +170,8 @@ final class SearchResultStore {
         self.illustOffset = 0
         self.userOffset = 0
         self.novelOffset = 0
+        self.illustNextURL = nil
+        self.novelNextURL = nil
         self.illustHasMore = false
         self.userHasMore = false
         self.novelHasMore = false
@@ -270,7 +274,7 @@ final class SearchResultStore {
                 self.illustOffset = illustBatch.nextOffset
                 self.illustHasMore = illustBatch.hasMore
             } else {
-                fetchedIllusts = try await api.searchIllusts(
+                let response = try await api.searchIllustsPage(
                     word: finalWord,
                     searchTarget: searchTarget.rawValue,
                     sort: sort,
@@ -280,8 +284,10 @@ final class SearchResultStore {
                     offset: 0,
                     limit: illustLimit
                 )
-                self.illustOffset = fetchedIllusts.count
-                self.illustHasMore = fetchedIllusts.count == illustLimit
+                fetchedIllusts = response.illusts
+                self.illustNextURL = response.nextUrl
+                self.illustOffset = nextOffset(from: response.nextUrl) ?? fetchedIllusts.count
+                self.illustHasMore = response.nextUrl != nil
             }
 
             self.illustResults = fetchedIllusts
@@ -475,19 +481,16 @@ final class SearchResultStore {
                     endDate: endDate
                 )
             } else {
-                let more = try await api.searchIllusts(
-                    word: finalWord,
-                    searchTarget: searchTarget.rawValue,
-                    sort: sort,
-                    searchAIType: searchAITypeParameter(for: showsAIGenerated),
-                    startDate: startDate,
-                    endDate: endDate,
-                    offset: self.illustOffset,
-                    limit: self.illustLimit
-                )
-                self.illustResults = mergeUniqueResults(self.illustResults, with: more)
-                self.illustOffset += more.count
-                self.illustHasMore = more.count == illustLimit
+                guard let nextURL = self.illustNextURL else {
+                    self.illustHasMore = false
+                    isLoadingMoreIllusts = false
+                    return
+                }
+                let response: IllustsResponse = try await api.fetchNext(urlString: nextURL)
+                self.illustResults = mergeUniqueResults(self.illustResults, with: response.illusts)
+                self.illustNextURL = response.nextUrl
+                self.illustOffset = nextOffset(from: response.nextUrl) ?? self.illustResults.count
+                self.illustHasMore = response.nextUrl != nil
             }
         } catch {
             print("Failed to load more illusts: \(error)")
@@ -594,6 +597,9 @@ final class SearchResultStore {
         isLoading = true
         errorMessage = nil
         novelLoadMoreErrorMessage = nil
+        novelOffset = 0
+        novelNextURL = nil
+        novelHasMore = false
         self.novelPseudoPopularTargetCount = 0
         self.novelPseudoPopularSamplePageCount = 0
         self.novelPseudoPopularSessionID = UUID()
@@ -757,19 +763,16 @@ final class SearchResultStore {
                     endDate: endDate
                 )
             } else {
-                let more = try await api.searchNovels(
-                    word: finalWord,
-                    searchTarget: searchTarget.rawValue,
-                    sort: sort,
-                    searchAIType: searchAITypeParameter(for: showsAIGenerated),
-                    startDate: startDate,
-                    endDate: endDate,
-                    offset: self.novelOffset,
-                    limit: self.novelLimit
-                )
-                self.novelResults = mergeUniqueResults(self.novelResults, with: more)
-                self.novelOffset += more.count
-                self.novelHasMore = more.count == novelLimit
+                guard let nextURL = self.novelNextURL else {
+                    self.novelHasMore = false
+                    isLoadingMoreNovels = false
+                    return
+                }
+                let response: NovelResponse = try await api.fetchNext(urlString: nextURL)
+                self.novelResults = mergeUniqueResults(self.novelResults, with: response.novels)
+                self.novelNextURL = response.nextUrl
+                self.novelOffset = nextOffset(from: response.nextUrl) ?? self.novelResults.count
+                self.novelHasMore = response.nextUrl != nil
             }
         } catch {
             print("Failed to load more novels: \(error)")
@@ -857,7 +860,7 @@ final class SearchResultStore {
             return batch.items
         }
 
-        let fetchedNovels = try await api.searchNovels(
+        let response = try await api.searchNovelsPage(
             word: baseWord + context.bookmarkFilter.suffix,
             searchTarget: context.searchTarget.rawValue,
             sort: context.sort,
@@ -867,12 +870,26 @@ final class SearchResultStore {
             offset: 0,
             limit: novelLimit
         )
+        let fetchedNovels = response.novels
 
         if updatePseudoPopularState {
-            self.novelOffset = fetchedNovels.count
-            self.novelHasMore = fetchedNovels.count == novelLimit
+            self.novelNextURL = response.nextUrl
+            self.novelOffset = nextOffset(from: response.nextUrl) ?? fetchedNovels.count
+            self.novelHasMore = response.nextUrl != nil
         }
         return fetchedNovels
+    }
+
+    private func nextOffset(from nextURL: String?) -> Int? {
+        guard
+            let nextURL,
+            let components = URLComponents(string: nextURL),
+            let value = components.queryItems?.first(where: { $0.name == "offset" })?.value
+        else {
+            return nil
+        }
+
+        return Int(value)
     }
 
     private func searchIllustsByBookmarkCount(


### PR DESCRIPTION
## Summary
Use the API-provided `next_url` for regular search pagination so search results do not stop early when a page contains fewer items than the requested limit.

## Why
Pixiv search responses can still provide `next_url` even when the current page contains fewer items than `limit`. The current regular search path treats `count == limit` as the only signal for whether more results exist, and also advances pagination using the local item count. In spam-heavy or restricted search results, that can make the app stop after only a handful of items and immediately show `已经到底了` even though more pages are still available.

## What Changed
- add page-level search API helpers that preserve `next_url` for regular illust and novel search requests
- store the regular-search `next_url` in `SearchResultStore` and load subsequent pages through the API-provided URL
- derive the next offset from `next_url` instead of the locally merged result count
- reset regular novel pagination state when starting a new search so stale paging state is not reused

## Result
- regular search pagination no longer ends early just because a page returned fewer items than `limit`
- illust and novel searches continue loading as long as the API exposes a `next_url`
- spam-heavy searches with local blacklist filtering are less likely to get stuck after the first sparse page

## Testing
- compiled successfully in the fork's workflow
- verified on iPhone and the pagination behavior matches the expected result
